### PR TITLE
feat: add PR-resolution skills and adversarial review pipeline

### DIFF
--- a/.claude/prompts/adversarial_implementer.md
+++ b/.claude/prompts/adversarial_implementer.md
@@ -67,5 +67,7 @@ contrary):
 Empty sections: `(none)`. Do not omit a heading.
 
 After this report, the orchestrator will rerun the reviewer over the
-new diff. Convergence = reviewer returns zero `### Blocking` findings
-and you have a recorded verdict on every prior finding.
+new diff. Convergence is decided by the orchestrator (see
+`local-pr-review`): the reviewer returns zero `### Blocking` AND zero
+`### Non-blocking` findings (SUSPECT items are advisory) and you have
+a recorded verdict on every prior finding.

--- a/.claude/prompts/adversarial_implementer.md
+++ b/.claude/prompts/adversarial_implementer.md
@@ -1,10 +1,7 @@
 # Adversarial Implementer Prompt
 
-Shared by the local pre-push skill ([.claude/skills/local-pr-review/SKILL.md](../skills/local-pr-review/SKILL.md))
-and any future automation that needs the implementer-side stance. The
-stance itself is also summarised in
-[CLAUDE.md](../../CLAUDE.md) "Adversarial Code Review → implementer";
-keep that section a pointer, not a duplicate.
+Shared by the local skill ([.claude/skills/local-pr-review/SKILL.md](../skills/local-pr-review/SKILL.md))
+and any future automation that needs the implementer-side stance.
 
 ---
 
@@ -24,8 +21,8 @@ For every finding, pick exactly one verdict:
    move on.** Record one line: `ALREADY-FIXED <file:line> — see
    <prior fix>`.
 3. **invalid / false positive / by design → push back with evidence.**
-   Cite the exact section of `CLAUDE.md` / `CONTRIBUTING.md` / `AGENTS.md`
-   / `.github/copilot-instructions.md` that supports your position, or
+   Cite the exact section of `AGENTS.md` / `README.md` /
+   `src/object_detection/README.md` that supports your position, or
    the `file:line` of code that disproves the comment. "I disagree" is
    not a reply. Record one line: `PUSH-BACK <file:line> — <one-line
    reason> — <citation>`.
@@ -33,17 +30,21 @@ For every finding, pick exactly one verdict:
 Standing project conventions (these trump reviewer suggestions to the
 contrary):
 
-- Required config fields must NOT have defaults — fail-fast at boot is
-  intentional. Reject "add a default for safety" suggestions on
-  caller-required params.
-- Editing a YAML value: change only the value line. Never strip the
-  surrounding comments.
-- Vehicle dimensions (wheelbase, track, max steering) live in
-  `src/tron_racer_bringup/config/default/description/car.yaml`.
-  Consumer nodes receive them via launch-file param passing, never via
-  literal duplication.
-- Runtime nodes reachable from `car.launch.py` are C++ (rclcpp /
-  ament_cmake). `ament_python` is for off-car tooling only.
+- Commits follow Conventional Commits per `AGENTS.md`.
+- Numbered exercises in `src/example_exercises/` are deliberately
+  self-contained teaching scripts for students. Reject "DRY this across
+  exercises" suggestions when they hurt readability; shared detection
+  logic belongs in `src/object_detection/`, not the other way around.
+- The `sys.path.insert(...)`-before-import pattern at the top of
+  exercises is established repo style — reject "move all imports to the
+  top of the file" findings against it (flake8 E402 is expected there).
+- `DEBUG_MODE` / `NO_TAKEOFF` are module-level flags students edit by
+  hand — reject refactors that turn them into CLI arguments or config
+  files unless the PR is explicitly about that.
+- Drone-safety guards (signal handlers, emergency landing, RC clamping
+  to [-100, 100], takeoff guarded by the mode flags) are load-bearing.
+  A reviewer finding that a change weakens them is almost certainly
+  valid; a reviewer suggestion that would weaken them is invalid.
 - `SUSPECT`-labelled findings still require investigation — but the bar
   for fixing is "I confirmed the smell is real", not "the reviewer
   mentioned it".

--- a/.claude/prompts/adversarial_implementer.md
+++ b/.claude/prompts/adversarial_implementer.md
@@ -69,5 +69,9 @@ Empty sections: `(none)`. Do not omit a heading.
 After this report, the orchestrator will rerun the reviewer over the
 new diff. Convergence is decided by the orchestrator (see
 `local-pr-review`): the reviewer returns zero `### Blocking` AND zero
-`### Non-blocking` findings (SUSPECT items are advisory) and you have
-a recorded verdict on every prior finding.
+`### Non-blocking` findings and you have a recorded verdict on every
+prior finding — **including every SUSPECT**. SUSPECT items are
+advisory for the convergence counts, but they never bypass your pass:
+a SUSPECT-only review still gets an implementer iteration that
+investigates and records a verdict for each one before the loop may
+settle.

--- a/.claude/prompts/adversarial_reviewer.md
+++ b/.claude/prompts/adversarial_reviewer.md
@@ -1,7 +1,7 @@
 # Adversarial Reviewer Prompt
 
 Shared by both the GitHub Action ([.github/workflows/claude-code-review.yml](../../.github/workflows/claude-code-review.yml))
-and the local pre-push skill ([.claude/skills/local-pr-review/SKILL.md](../skills/local-pr-review/SKILL.md)).
+and the local skill ([.claude/skills/local-pr-review/SKILL.md](../skills/local-pr-review/SKILL.md)).
 Keep this file the single source of truth — change here, both caller paths follow.
 
 ---
@@ -21,10 +21,10 @@ Ground rules:
 - Only the CHANGED lines (and code they touch) are in scope. Do not
   lecture about pre-existing code unless the diff makes it actively
   worse.
-- Read `CLAUDE.md` (and the docs it links), `AGENTS.md`,
-  `CONTRIBUTING.md`, and `.github/copilot-instructions.md` before
-  writing the review. A comment that contradicts those files is itself
-  a defect — you will be challenged on it.
+- Read `AGENTS.md`, `README.md`, and `src/object_detection/README.md`
+  (any that exist) before writing the review. A comment that
+  contradicts those files is itself a defect — you will be challenged
+  on it.
 - Cite file:line for every finding. Quote the offending snippet when it
   clarifies the point.
 - No praise, no "LGTM", no summary of what the PR does. The author
@@ -37,22 +37,23 @@ Ground rules:
 
 Hunt for (non-exhaustive):
 
-- Bugs, off-by-ones, null/empty/NaN edge cases, integer overflow, unit
-  mismatches (rad vs deg, m vs mm, ERPM vs rpm)
-- Race conditions, missing locks, callback re-entrancy,
-  publish-from-timer-vs-subscriber assumptions
-- Topic / frame / param name drift vs the conventions in `CLAUDE.md`
-  "Topic Namespacing Convention" and "Key Topics"
+- Bugs, off-by-ones, null/empty/NaN edge cases, unit mismatches
+  (rad vs deg, px vs cm, cm/s vs the Tello RC's -100..100 scale)
+- Vision/CV bugs: HSV hue ranges using 0–360 instead of OpenCV's 0–179;
+  RGB vs BGR confusion (Tello `get_frame_read().frame` is RGB and must
+  be converted before OpenCV color ops); wrong mask dtype; contour /
+  bounding-box coordinate mixups; kernel sizes that must be odd
+- Drone-safety hazards: takeoff / `send_rc_control` paths not guarded
+  by `DEBUG_MODE` / `NO_TAKEOFF`; removed or broken SIGINT/SIGTERM
+  handlers and emergency-landing cleanup; RC velocities not clamped to
+  [-100, 100]; loops that can spin without landing on exit
+- Frame-loop hazards: blocking I/O or heavy allocation per frame,
+  missing frame pacing, unbounded reconnect retries
 - Stale doc / comment / config drift introduced by the diff
-- Dead code, unused params, copy-paste from a sibling node that no
-  longer fits
+- Dead code, unused params, copy-paste from a sibling exercise that no
+  longer fits its new context
 - Missing tests for new branches, regressions in existing tests, tests
   that assert the implementation instead of the requirement
-- Realtime hazards on car-launched code: blocking I/O, allocations in
-  hot paths, `ament_python` nodes reachable from `car.launch.py` (banned
-  per CONTRIBUTING.md "Code Style" → "Language choice")
-- Launch-arg / facade-pattern violations, missing `simulated`
-  propagation, sim-vs-real divergence in sensor rates
 - Security & supply-chain: unpinned actions, shell injection in
   workflows, secrets logged or written to disk
 

--- a/.claude/skills/local-pr-review/SKILL.md
+++ b/.claude/skills/local-pr-review/SKILL.md
@@ -9,7 +9,9 @@ Mirror of [.github/workflows/claude-code-review.yml](../../../.github/workflows/
 run locally, in an isolated git worktree, with the implementer agent in
 the same session pushing back on weak findings and fixing real ones.
 Loops until reviewer and implementer agree, then fast-forwards the
-original branch and exits 0.
+original branch and reports success. Non-convergence (stable
+disagreement or the iteration cap) is always reported as a failure
+with the outstanding findings — never as a pass.
 
 ## When to use
 
@@ -41,10 +43,20 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 Each `Agent` call uses `isolation: "worktree"`. The worktree is
 checked out to `HEAD_REF`. No manual `git worktree add` from the skill.
 
-If the current branch is already checked out in another worktree
-(`git worktree list --porcelain | grep "branch refs/heads/${BRANCH}"`
-returns a path other than the current one), abort with
-`blocked-active-worktree` so the user resolves by hand.
+If the current branch is already checked out in another worktree,
+abort with `blocked-active-worktree` so the user resolves by hand.
+`--porcelain` output pairs each `worktree <path>` line with its
+`branch` line, so parse the pairs and compare paths — a bare grep for
+the branch line can't tell which worktree it belongs to:
+
+```bash
+current=$(git rev-parse --show-toplevel)
+other=$(git worktree list --porcelain \
+  | awk -v ref="branch refs/heads/${BRANCH}" \
+      '/^worktree /{p=substr($0,10)} $0==ref{print p}' \
+  | grep -vFx "$current" || true)
+[ -n "$other" ] && echo "blocked-active-worktree: $other" && stop
+```
 
 ### 3. Reviewer pass
 
@@ -123,8 +135,14 @@ loop forever — the user can inspect, decide, and push anyway.
 
 When converged:
 
-1. In the worktree, delete `HISTORY.md` (it's loop scratch, not PR
-   content), then stage every edit the implementer made: `git add -A`.
+1. In the worktree, collect the file list the implementer reported
+   touching (the `FIXED <file:line>` lines in `HISTORY.md`), then
+   delete `HISTORY.md` (it's loop scratch, not PR content). Stage
+   exactly the reported files with `git add -- <file>...` — never
+   `git add -A`. If `git status --porcelain` still shows modified or
+   untracked files after that, stop and surface them to the user
+   instead of staging; stray agent artifacts must not ride into the
+   commit.
 2. If the worktree's index is non-empty, fold the loop's work into a
    single commit: `git commit -m "fixup! adversarial review iteration
    loop"` (the user squashes it when merging).

--- a/.claude/skills/local-pr-review/SKILL.md
+++ b/.claude/skills/local-pr-review/SKILL.md
@@ -94,9 +94,18 @@ Parse the `bot-review-marker` HTML comment:
 blocking=(\d+) nonblocking=(\d+) suspect=(\d+)
 ```
 
-If `blocking == 0` AND `nonblocking == 0` (suspect items are advisory):
-**converged**. Print `=== CONVERGED at iteration ${ITER} ===`, jump to
-step 6.
+If `blocking == 0` AND `nonblocking == 0` AND every SUSPECT finding in
+this iteration already has a recorded implementer verdict in
+`HISTORY.md`: **converged**. Print `=== CONVERGED at iteration
+${ITER} ===`, jump to step 6.
+
+If the blocking/nonblocking counts are zero but one or more SUSPECT
+findings lack a verdict, do NOT settle yet — SUSPECT is advisory for
+the counts, but it never skips the implementer's investigation. Run
+step 5 so the implementer investigates each SUSPECT and records a
+verdict. If that pass makes no code edits, treat the loop as converged
+when it returns; if it does edit files, loop to step 3 as usual so the
+reviewer sees the new diff.
 
 If the reviewer's findings are byte-identical to the previous
 iteration's findings: **stable disagreement**. Print the unresolved
@@ -139,10 +148,18 @@ When converged:
    touching (the `FIXED <file:line>` lines in `HISTORY.md`), then
    delete `HISTORY.md` (it's loop scratch, not PR content). Stage
    exactly the reported files with `git add -- <file>...` — never
-   `git add -A`. If `git status --porcelain` still shows modified or
-   untracked files after that, stop and surface them to the user
-   instead of staging; stray agent artifacts must not ride into the
-   commit.
+   `git add -A`. Then check for strays among **unstaged and untracked
+   paths only** — the just-staged allowlisted files legitimately show
+   as staged, so a bare `git status --porcelain` would false-positive
+   on a successful fixup:
+
+   ```bash
+   strays=$(git diff --name-only; git ls-files --others --exclude-standard)
+   ```
+
+   If `strays` is non-empty, stop and surface the list to the user
+   instead of staging more; stray agent artifacts must not ride into
+   the commit.
 2. If the worktree's index is non-empty, fold the loop's work into a
    single commit: `git commit -m "fixup! adversarial review iteration
    loop"` (the user squashes it when merging).

--- a/.claude/skills/local-pr-review/SKILL.md
+++ b/.claude/skills/local-pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: local-pr-review
-description: Run the adversarial Claude review locally in a git worktree before a push, looping reviewer ↔ implementer until consensus. Drop-in replacement for the GitHub Actions claude-code-review run so CI runner minutes aren't burned on every PR sync. Invoked by the pre-push hook and the gh-pr-create wrapper, but also runnable as /local-pr-review.
+description: Run the adversarial Claude review locally in a git worktree before a push, looping reviewer ↔ implementer until consensus. Local counterpart of the claude-code-review GitHub workflow so findings surface before CI runner minutes are burned. Run as /local-pr-review against the current branch.
 ---
 
 # local-pr-review
@@ -9,27 +9,22 @@ Mirror of [.github/workflows/claude-code-review.yml](../../../.github/workflows/
 run locally, in an isolated git worktree, with the implementer agent in
 the same session pushing back on weak findings and fixing real ones.
 Loops until reviewer and implementer agree, then fast-forwards the
-original branch and exits 0 so the push proceeds.
+original branch and exits 0.
 
 ## When to use
 
-- Pre-push hook fires this automatically when pushing a branch that has
-  an open PR (see [bin/pre_push_claude_review.sh](../../../bin/pre_push_claude_review.sh)).
-- [bin/gh-pr-create-with-review.sh](../../../bin/gh-pr-create-with-review.sh)
-  fires it before creating a new PR.
-- Manually as `/local-pr-review` against the current branch.
+- Manually as `/local-pr-review` against the current branch, before
+  pushing a branch that has (or is about to get) an open PR.
+- This repo has no pre-push hook wiring; invocation is always manual.
 
 ## Inputs
 
-Caller may pass `BASE_REF` and `HEAD_REF` via env. Resolve `HEAD_REF` first —
-`BASE_REF`, `BRANCH`, and the banner all derive from it, so a caller-supplied
-`HEAD_REF` must not fall back to the current checkout:
+Caller may pass `BASE_REF` and `HEAD_REF` via env. If absent:
 
 ```bash
+BASE_REF=${BASE_REF:-$(git merge-base HEAD origin/main)}
 HEAD_REF=${HEAD_REF:-HEAD}
-git fetch origin main
-BASE_REF=${BASE_REF:-$(git merge-base "$HEAD_REF" origin/main)}
-BRANCH=$(git rev-parse --abbrev-ref "$HEAD_REF")
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
 ```
 
 ## Flow
@@ -37,35 +32,19 @@ BRANCH=$(git rev-parse --abbrev-ref "$HEAD_REF")
 ### 1. Pre-flight
 
 - Refuse to run on `main` — there's no PR concept.
-- `origin main` was already fetched while resolving `BASE_REF` above, so
-  the merge-base is fresh by the time this step runs.
+- `git fetch origin main` so the merge-base is fresh.
 - Show a one-line banner: `=== LOCAL ADVERSARIAL REVIEW: ${BRANCH}
-  (BASE..HEAD = $(git rev-parse --short "$BASE_REF")..$(git rev-parse
-  --short "$HEAD_REF")) ===`. (Resolve via `rev-parse` — substring
-  slicing like `${HEAD_REF:0:7}` prints garbage for symbolic refs such
-  as `HEAD` or `origin/main`.)
-- Print the bypass hint: `Bypass with CLAUDE_LOCAL_REVIEW=0 or git push
-  --no-verify.`
+  (BASE..HEAD = ${BASE_REF:0:7}..${HEAD_REF:0:7}) ===`.
 
 ### 2. Worktree
 
-Reuse the worktree pattern from
-[.claude/skills/resolve-my-prs/SKILL.md](../resolve-my-prs/SKILL.md):
-each `Agent` call uses `isolation: "worktree"`. The worktree is
+Each `Agent` call uses `isolation: "worktree"`. The worktree is
 checked out to `HEAD_REF`. No manual `git worktree add` from the skill.
 
-If the current branch is already checked out in another worktree, abort
-with `blocked-active-worktree` so the user resolves by hand. Parse the
-porcelain output structurally (exact-match the branch ref — a regex
-`grep` misfires on branch names with metacharacters or shared prefixes):
-
-```bash
-git worktree list --porcelain \
-  | awk -v ref="refs/heads/${BRANCH}" -v cur="$(git rev-parse --show-toplevel)" \
-      '/^worktree /{wt=substr($0,10)} $0=="branch "ref && wt!=cur{print wt}'
-```
-
-Non-empty output means another worktree has `${BRANCH}` checked out.
+If the current branch is already checked out in another worktree
+(`git worktree list --porcelain | grep "branch refs/heads/${BRANCH}"`
+returns a path other than the current one), abort with
+`blocked-active-worktree` so the user resolves by hand.
 
 ### 3. Reviewer pass
 
@@ -76,12 +55,9 @@ the user sees each turn live). Prompt body:
 ```text
 You are running inside an isolated git worktree off branch ${BRANCH}.
 Read the adversarial reviewer prompt at .claude/prompts/adversarial_reviewer.md
-and follow it exactly. The diff under review (commit-to-working-tree form —
-the implementer's edits from earlier iterations are deliberately left
-uncommitted in this worktree, and a two-endpoint `${BASE_REF}..${HEAD_REF}`
-diff would never show them):
+and follow it exactly. The diff under review:
 
-  git diff ${BASE_REF}
+  git diff ${BASE_REF}..${HEAD_REF}
 
 Iteration: ${ITER} of max ${MAX_ITER}.
 Previous iterations' findings + implementer verdicts are in HISTORY.md
@@ -112,9 +88,7 @@ step 6.
 
 If the reviewer's findings are byte-identical to the previous
 iteration's findings: **stable disagreement**. Print the unresolved
-list and exit with status 2 so the hook surfaces it to the user
-("reviewer and implementer can't agree — review the report and decide
-whether to bypass").
+list and stop with a clear report so the user can review and decide.
 
 ### 5. Implementer pass
 
@@ -141,24 +115,19 @@ Print `=== ITERATION ${ITER} — IMPLEMENTER ===` banner. Increment
 
 ### 6. Hard cap
 
-`MAX_ITER = 5`. If reached without convergence, print the outstanding
-findings and exit with status 2. Do not loop forever — the user can
-inspect, decide, and re-push.
+`MAX_ITER = 5` (override with `LOCAL_REVIEW_MAX_ITER=N`). If reached
+without convergence, print the outstanding findings and stop. Do not
+loop forever — the user can inspect, decide, and push anyway.
 
 ### 7. Settling the worktree back into the original branch
 
 When converged:
 
-1. In the worktree, delete the loop transcript first — it is scratch
-   state and must never ship: `rm -f HISTORY.md`. Then stage every edit
-   the implementer made: `git add -A`. (Without the delete, `git add -A`
-   would stage `HISTORY.md` and push every review transcript with the
-   branch.)
-2. If the worktree's index is non-empty, amend onto a single fixup
-   commit: `git commit --no-verify -m "fixup! adversarial review
-   iteration loop"`. (`--no-verify` is intentional here — pre-commit
-   hooks are about *intent*, this commit is a mechanical re-shape of
-   the diff the user is about to push.)
+1. In the worktree, delete `HISTORY.md` (it's loop scratch, not PR
+   content), then stage every edit the implementer made: `git add -A`.
+2. If the worktree's index is non-empty, fold the loop's work into a
+   single commit: `git commit -m "fixup! adversarial review iteration
+   loop"` (the user squashes it when merging).
 3. Back in the main checkout, fast-forward `${BRANCH}` to the
    worktree's HEAD: `git fetch <worktree-path> HEAD:${BRANCH}` (or
    `git update-ref refs/heads/${BRANCH} <new-sha>` if the main
@@ -166,30 +135,20 @@ When converged:
 4. If the implementer made no edits in any iteration (clean pass on
    the first reviewer round), skip the fixup commit and the
    fast-forward — nothing to settle.
-5. Print `=== LOCAL REVIEW PASSED — push proceeding ===` and exit 0.
-
-## Bypass channels
-
-- `CLAUDE_LOCAL_REVIEW=0` env — skill exits 0 immediately when set.
-  The pre-push hook short-circuits before calling the skill, so this
-  is the fast path.
-- `git push --no-verify` — git skips the pre-push hook entirely, so the
-  skill is never invoked.
-- Skill caller may pass `LOCAL_REVIEW_MAX_ITER=N` to override the cap.
+5. Print `=== LOCAL REVIEW PASSED ===`.
 
 ## Outputs
 
-- Exit 0 → converged (or bypassed), push proceeds.
-- Exit 2 → unresolved findings, push aborted, user decides next step.
-- Exit non-zero non-2 → setup error (no worktree, no `claude` binary,
-  etc.) — pre-push hook surfaces with a clear message.
+- Converged → report "passed", branch fast-forwarded if edits were made.
+- Stable disagreement or iteration cap → report the outstanding
+  findings; the user decides whether to fix by hand or push anyway.
 
 ## Ground rules
 
 - **Foreground only.** Never `run_in_background`. The user must see
   each iteration as it happens.
-- **The skill does not push.** It returns control to the pre-push
-  hook (or wrapper), which pushes only if the skill exited 0.
+- **The skill does not push.** It leaves the branch ready; the user
+  (or /resolve-my-prs) pushes.
 - **The skill does not post to GitHub.** The matching workflow run
   will still fire on the actual push; this is local-only.
 - **One commit max.** Don't litter the branch with per-iteration
@@ -202,6 +161,5 @@ When converged:
 
 - [.claude/prompts/adversarial_reviewer.md](../../prompts/adversarial_reviewer.md) — reviewer prompt body (single source of truth)
 - [.claude/prompts/adversarial_implementer.md](../../prompts/adversarial_implementer.md) — implementer prompt body
-- [bin/pre_push_claude_review.sh](../../../bin/pre_push_claude_review.sh) — pre-push hook caller
-- [bin/gh-pr-create-with-review.sh](../../../bin/gh-pr-create-with-review.sh) — `gh pr create` wrapper
+- [resolve-my-prs](../resolve-my-prs/SKILL.md) — bulk PR resolution loop that this skill complements
 - [.github/workflows/claude-code-review.yml](../../../.github/workflows/claude-code-review.yml) — the CI workflow this mirrors

--- a/.claude/skills/local-pr-review/SKILL.md
+++ b/.claude/skills/local-pr-review/SKILL.md
@@ -21,12 +21,15 @@ with the outstanding findings — never as a pass.
 
 ## Inputs
 
-Caller may pass `BASE_REF` and `HEAD_REF` via env. If absent:
+Caller may pass `BASE_REF` and `HEAD_REF` via env. Resolve `HEAD_REF` first —
+`BASE_REF`, `BRANCH`, and the banner all derive from it, so a caller-supplied
+`HEAD_REF` must not fall back to the current checkout:
 
 ```bash
-BASE_REF=${BASE_REF:-$(git merge-base HEAD origin/main)}
 HEAD_REF=${HEAD_REF:-HEAD}
-BRANCH=$(git rev-parse --abbrev-ref HEAD)
+git fetch origin main
+BASE_REF=${BASE_REF:-$(git merge-base "$HEAD_REF" origin/main)}
+BRANCH=$(git rev-parse --abbrev-ref "$HEAD_REF")
 ```
 
 ## Flow
@@ -34,9 +37,13 @@ BRANCH=$(git rev-parse --abbrev-ref HEAD)
 ### 1. Pre-flight
 
 - Refuse to run on `main` — there's no PR concept.
-- `git fetch origin main` so the merge-base is fresh.
+- `origin main` was already fetched while resolving `BASE_REF` above, so
+  the merge-base is fresh by the time this step runs.
 - Show a one-line banner: `=== LOCAL ADVERSARIAL REVIEW: ${BRANCH}
-  (BASE..HEAD = ${BASE_REF:0:7}..${HEAD_REF:0:7}) ===`.
+  (BASE..HEAD = $(git rev-parse --short "$BASE_REF")..$(git rev-parse
+  --short "$HEAD_REF")) ===`. (Resolve via `rev-parse` — substring
+  slicing like `${HEAD_REF:0:7}` prints garbage for symbolic refs such
+  as `HEAD` or `origin/main`.)
 
 ### 2. Worktree
 
@@ -67,9 +74,12 @@ the user sees each turn live). Prompt body:
 ```text
 You are running inside an isolated git worktree off branch ${BRANCH}.
 Read the adversarial reviewer prompt at .claude/prompts/adversarial_reviewer.md
-and follow it exactly. The diff under review:
+and follow it exactly. The diff under review (commit-to-working-tree form —
+the implementer's edits from earlier iterations are deliberately left
+uncommitted in this worktree, and a two-endpoint `${BASE_REF}..${HEAD_REF}`
+diff would never show them):
 
-  git diff ${BASE_REF}..${HEAD_REF}
+  git diff ${BASE_REF}
 
 Iteration: ${ITER} of max ${MAX_ITER}.
 Previous iterations' findings + implementer verdicts are in HISTORY.md
@@ -109,7 +119,9 @@ reviewer sees the new diff.
 
 If the reviewer's findings are byte-identical to the previous
 iteration's findings: **stable disagreement**. Print the unresolved
-list and stop with a clear report so the user can review and decide.
+list and stop with exit status 2 so a hook or wrapper surfaces it to
+the user ("reviewer and implementer can't agree — review the report
+and decide whether to bypass").
 
 ### 5. Implementer pass
 
@@ -137,8 +149,9 @@ Print `=== ITERATION ${ITER} — IMPLEMENTER ===` banner. Increment
 ### 6. Hard cap
 
 `MAX_ITER = 5` (override with `LOCAL_REVIEW_MAX_ITER=N`). If reached
-without convergence, print the outstanding findings and stop. Do not
-loop forever — the user can inspect, decide, and push anyway.
+without convergence, print the outstanding findings and stop with exit
+status 2. Do not loop forever — the user can inspect, decide, and push
+anyway.
 
 ### 7. Settling the worktree back into the original branch
 
@@ -161,8 +174,10 @@ When converged:
    instead of staging more; stray agent artifacts must not ride into
    the commit.
 2. If the worktree's index is non-empty, fold the loop's work into a
-   single commit: `git commit -m "fixup! adversarial review iteration
-   loop"` (the user squashes it when merging).
+   single commit: `git commit --no-verify -m "fixup! adversarial review
+   iteration loop"`. (`--no-verify` is intentional here — pre-commit
+   hooks are about *intent*, this commit is a mechanical re-shape of
+   the diff the user is about to push.)
 3. Back in the main checkout, fast-forward `${BRANCH}` to the
    worktree's HEAD: `git fetch <worktree-path> HEAD:${BRANCH}` (or
    `git update-ref refs/heads/${BRANCH} <new-sha>` if the main
@@ -174,9 +189,18 @@ When converged:
 
 ## Outputs
 
-- Converged → report "passed", branch fast-forwarded if edits were made.
-- Stable disagreement or iteration cap → report the outstanding
-  findings; the user decides whether to fix by hand or push anyway.
+- Exit 0 → converged (or bypassed), branch fast-forwarded if edits were made.
+- Exit 2 → unresolved findings (stable disagreement or iteration cap);
+  the user decides whether to fix by hand or push anyway.
+- Exit non-zero non-2 → setup error (no worktree, no `claude` binary,
+  blocked-active-worktree, etc.).
+
+## Bypass channels
+
+- `CLAUDE_LOCAL_REVIEW=0` env — skill exits 0 immediately when set.
+- `git push --no-verify` — git skips pre-push hooks entirely (there are
+  none wired in this repo today, but the flag is a universal bypass).
+- Caller may pass `LOCAL_REVIEW_MAX_ITER=N` to override the iteration cap.
 
 ## Ground rules
 

--- a/.claude/skills/resolve-my-prs/SKILL.md
+++ b/.claude/skills/resolve-my-prs/SKILL.md
@@ -113,13 +113,19 @@ this prompt:
 
 === Branch checkout ===
 
-  git fetch origin ${BRANCH}
-  git fetch origin ${DEFAULT_BRANCH}
-  git checkout -B local-${N} origin/${BRANCH}
-  git rebase origin/${DEFAULT_BRANCH}
+Treat `${BRANCH}` as untrusted input — it comes from GitHub metadata
+and git refnames may legally contain shell metacharacters (`;`, `$`,
+quotes, parens). Validate it once before first use and quote every
+expansion:
+
+  git check-ref-format --branch "${BRANCH}"   # abort blocked-bad-ref on failure
+  git fetch origin "${BRANCH}"
+  git fetch origin "${DEFAULT_BRANCH}"
+  git checkout -B "local-${N}" "origin/${BRANCH}"
+  git rebase "origin/${DEFAULT_BRANCH}"
   # ...do work...
   # ...run the pre-push gate (see below)...
-  git push --force-with-lease origin local-${N}:${BRANCH}
+  git push --force-with-lease origin "local-${N}:${BRANCH}"
 
 If `git rebase origin/${DEFAULT_BRANCH}` hits a conflict whose intent is
 genuinely ambiguous after consulting code, history, and PR description,
@@ -153,9 +159,11 @@ black/flake8 repo-wide, so the gate is scoped to the files this PR
 touches. Tools are pinned in requirements.txt (black, flake8, pytest).
 Run from the repo root and fix any failure before pushing:
 
-  CHANGED=$(git diff --name-only origin/${DEFAULT_BRANCH}...HEAD -- '*.py')
-  [ -n "$CHANGED" ] && black --check $CHANGED
-  [ -n "$CHANGED" ] && flake8 --max-line-length 88 --extend-ignore E203,E402 $CHANGED
+  # NUL-delimited into an array so filenames with spaces, globs, or
+  # leading dashes can't be split or read as options.
+  mapfile -d '' CHANGED < <(git diff -z --name-only "origin/${DEFAULT_BRANCH}...HEAD" -- '*.py')
+  ((${#CHANGED[@]})) && black --check -- "${CHANGED[@]}"
+  ((${#CHANGED[@]})) && flake8 --max-line-length 88 --extend-ignore E203,E402 -- "${CHANGED[@]}"
   pytest -q || [ $? -eq 5 ]   # exit 5 = "no tests collected" — fine today,
                               # mandatory so broken tests can't ship later
 
@@ -347,7 +355,7 @@ Threads you intentionally left open should be called out in `Notes`.
 
 Run the pre-push gate above. Then:
 
-  git push --force-with-lease origin local-${N}:${BRANCH}
+  git push --force-with-lease origin "local-${N}:${BRANCH}"
 
 Do NOT wait for CI. Return immediately after the push so the
 orchestrator can move on. CI babysitting belongs to the circle-back
@@ -409,7 +417,7 @@ the CI run from the prior pass.
 
 4. **Same push policy.** Before pushing the fix, rebase on `origin/${DEFAULT_BRANCH}` again, re-run the pre-push gate, then `git push --force-with-lease`. Resolve any threads you addressed via the GraphQL mutation.
 
-5. **Repeat the circle-back** by re-fanning out over the still-open PRs until every PR is mergeable: no conflicts, all required checks green, all threads resolved. Each round is its own parallel fan-out under the same `MAX_CONCURRENT` cap.
+5. **Repeat the circle-back** by re-fanning out over the still-open PRs until every PR is mergeable: no conflicts, all required checks green, all threads resolved. Each round is its own parallel fan-out under the same `MAX_CONCURRENT` cap. **Hard cap: `MAX_ROUNDS = 3` circle-back rounds per invocation.** A PR that still has open work after the cap is marked `blocked-circle-back-limit` in the final report — with the unresolved check or thread URL and the rounds spent — and excluded from the merge order. Never keep re-dispatching past the cap; a run that hasn't settled in 3 rounds needs the user, not more agents.
 
 6. **Genuine blocker → stop and surface it.** If an Agent returns `blocked-<reason>` for ambiguous conflict, CI failure with no clear cause after honest investigation, or two comments that contradict each other where neither matches the PR's business intent, surface the blocker in the final report with the specific PR number, the failing check or thread URL, and what was already tried. Do not re-dispatch the same PR with the same prompt hoping for a different answer.
 

--- a/.claude/skills/resolve-my-prs/SKILL.md
+++ b/.claude/skills/resolve-my-prs/SKILL.md
@@ -160,8 +160,10 @@ touches. Tools are pinned in requirements.txt (black, flake8, pytest).
 Run from the repo root and fix any failure before pushing:
 
   # NUL-delimited into an array so filenames with spaces, globs, or
-  # leading dashes can't be split or read as options.
-  mapfile -d '' CHANGED < <(git diff -z --name-only "origin/${DEFAULT_BRANCH}...HEAD" -- '*.py')
+  # leading dashes can't be split or read as options. --diff-filter=ACMR
+  # excludes deleted paths so black/flake8 aren't pointed at files that
+  # no longer exist.
+  mapfile -d '' CHANGED < <(git diff -z --diff-filter=ACMR --name-only "origin/${DEFAULT_BRANCH}...HEAD" -- '*.py')
   ((${#CHANGED[@]})) && black --check -- "${CHANGED[@]}"
   ((${#CHANGED[@]})) && flake8 --max-line-length 88 --extend-ignore E203,E402 -- "${CHANGED[@]}"
   pytest -q || [ $? -eq 5 ]   # exit 5 = "no tests collected" — fine today,

--- a/.claude/skills/resolve-my-prs/SKILL.md
+++ b/.claude/skills/resolve-my-prs/SKILL.md
@@ -1,58 +1,451 @@
 ---
 name: resolve-my-prs
-description: Claude adapter for the repo's agent-agnostic bulk PR resolution workflow.
+description: Walk every open PR authored by the current GitHub user, address unresolved review comments (human + bot), rebase + force-with-lease push only when changes are needed, circle back for CI, and report the final merge order. Pipelined dispatch loop — push and move on, don't block on CI.
 ---
 
 # resolve-my-prs
 
-This is a Claude-specific adapter. The repo policy and orchestration contract
-live in [docs/agent-workflows/pr-resolution.md](../../../docs/agent-workflows/pr-resolution.md)
-and [AGENTS.md](../../../AGENTS.md). Read both before dispatching any work.
+Dispatch loop for grinding through a backlog of your open PRs in this repo. The outer orchestrator enumerates the queue and **fans out one Agent per PR in parallel, each in its own git worktree**. The outer orchestrator only does enumeration, dispatch, and final reporting — it never touches branches itself. After the fan-out completes, the outer orchestrator collects results and prints the merge order.
 
-## Claude Adapter Mapping
+This skill is **self-contained**. Per-PR mechanics (auth, comment fetch, GraphQL thread resolution, push policy, CI debug, conflict resolution) are inlined below. The per-PR agent must read `AGENTS.md` (and `CLAUDE.md` / `CONTRIBUTING.md` if they exist) first — those files contain standing conventions that override the generic guidance here.
 
-- Treat `docs/agent-workflows/pr-resolution.md` as the canonical bulk-PR
-  workflow.
-- Use Claude background Agents only as the runtime mechanism for the document's
-  "Bulk PR Flow" and "Per-PR Worker Contract".
-- Dispatch at most 4 concurrent Agents.
-- Use `isolation: "worktree"` for every per-PR Agent.
-- Use `run_in_background: true` for bulk first-pass and circle-back Agents.
-- Skip PRs whose branch is already checked out in another local worktree.
-- Keep per-PR mechanics in AGENTS.md; do not duplicate commands here.
+## When to use
 
-## Prompt Stub
+- Invoked manually as `/resolve-my-prs` when you want to clear your whole PR backlog in one sitting.
+- Not for one-off PR work. If you're fixing comments on a single PR, do that in plain conversation. The overhead of the dispatch loop only pays off when there are several PRs to grind through.
 
-For each PR, pass the worker enough identity context to execute the canonical
-workflow:
+## Scope (hard limits)
+
+- **Only PRs authored by the current GitHub user.** Determined by `gh api user -q .login` at the start of the run and never widened.
+- **Only open PRs.** Skip draft PRs unless the user explicitly says otherwise.
+- **Never merge the default branch into a feature branch.** Always rebase on `origin/<default-branch>` (detect with `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`).
+- **Always `--force-with-lease`.** Never plain `--force`.
+- **Never bypass checks.** No `--no-verify`, no disabling lint rules, no skipping/deleting tests to make CI green. Fix the underlying issue.
+
+## Pre-flight (once per invocation, in the outer orchestrator)
+
+The outer orchestrator stays in the main checkout. It only runs read-only `gh` and `git` commands. Per-PR worktrees are created by each fanned-out Agent via `isolation: "worktree"` — the orchestrator does **not** create them itself.
+
+Parallel fan-out is the only mode this skill describes. If a user explicitly asks for sequential processing, ignore the skill and process the queue one PR at a time in plain conversation — the per-PR template below is parameterised for a single `${N}` and would need rewriting to drive a loop.
+
+1. Auth:
+
+   ```bash
+   gh auth status
+   ```
+
+2. Identify yourself and lock the author scope:
+
+   ```bash
+   ME=$(gh api user -q .login)
+   ```
+
+3. Derive repo slug + default branch once so every downstream `gh api` call has explicit strings:
+
+   ```bash
+   OWNER=$(gh repo view --json owner -q .owner.login)
+   REPO=$(gh repo view --json name  -q .name)
+   DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+   ```
+
+4. Pull the work queue using the locked `$ME` scope:
+
+   ```bash
+   gh pr list --author "$ME" --state open \
+     --json number,title,headRefName,isDraft,mergeable,mergeStateStatus
+   ```
+
+   Filter out drafts. Use `$ME` consistently rather than `@me` — `@me` resolves at request time and could drift if auth context changes mid-run.
+
+5. Refresh the default branch once up front so rebase targets are fresh:
+
+   ```bash
+   git fetch origin "$DEFAULT_BRANCH"
+   ```
+
+6. Remember where you started — `ORIGINAL_BRANCH=$(git rev-parse --abbrev-ref HEAD)` — so you can return at the end.
+
+## First pass — parallel fan-out (one Agent per PR, capped concurrency)
+
+After the queue is enumerated, **fan out**: send a message containing up to `MAX_CONCURRENT` `Agent` tool calls. Each call MUST include:
+
+- `subagent_type: "general-purpose"`
+- `isolation: "worktree"` — each agent gets its own worktree off the default branch
+- `run_in_background: true` — **critical**. Without this, multiple `Agent` calls in one message run concurrently but the orchestrator's turn blocks until every one returns synchronously. With `run_in_background: true`, each agent fires a completion notification when done; the orchestrator's turn ends immediately after dispatch and is re-invoked on each completion. The notification model is what enables the "push and move on" semantics.
+
+**Concurrency cap: `MAX_CONCURRENT = 4`.** Dispatch at most 4 Agent calls in the first message. On each completion notification, if the queue still has PRs, dispatch one replacement Agent so the in-flight count stays ≈4 until the queue drains. The notification-driven backfill preserves "push and move on" — no polling, no sleep. **Rationale:** an unbounded burst dispatch on a sibling project exhausted the Anthropic session budget mid-run and saturated the laptop's worktree / I/O. If session-limit errors still occur with cap=4, lower it further rather than raising it. When the queue exceeds `MAX_CONCURRENT`, the orchestrator prints `"Dispatching N PRs in batches of <MAX_CONCURRENT> — will take ~X minutes"` so the user knows the run is paced.
+
+The orchestrator's job after fan-out: wait for each completion notification, dispatch a replacement Agent if any PRs remain in the queue, accumulate the per-PR reports, and once all agents have reported, assemble the merge order. It does **not** touch any branch itself.
+
+### Worktree-collision rule
+
+If a PR's branch is already checked out in another worktree on this machine, **skip that PR** and mark its outcome as `blocked-active-worktree` in the final report. Fanning out an agent that fights with the user's live edits is worse than skipping. The outer orchestrator detects this with `git worktree list --porcelain` before dispatching.
+
+### Per-PR Agent prompt template
+
+Each fanned-out Agent receives a prompt built from this template, with `${N}`, `${BRANCH}`, `${OWNER}`, `${REPO}`, `${DEFAULT_BRANCH}`, and any PR-specific hints filled in by the outer orchestrator:
 
 ```text
-You are processing PR #${N} on branch `${BRANCH}` for `${ME}` in
-`${OWNER}/${REPO}`.
+You are processing a single open PR (#${N}, branch `${BRANCH}`) for user
+`${ME}` in repo `${OWNER}/${REPO}`. The repo's default branch is
+`${DEFAULT_BRANCH}`. You are running in a fresh git worktree off
+origin/${DEFAULT_BRANCH} (created by isolation: "worktree").
 
-Follow docs/agent-workflows/pr-resolution.md and AGENTS.md directly. You are a
-per-PR worker in an isolated worktree. Assess and resolve every review thread
-regardless of author — CodeRabbit, Copilot, Claude, and human reviewers all
-count; verify zero unresolved threads remain (AGENTS.md §5 Step 6) before
-reporting. Return the normalized per-PR report described by
-docs/agent-workflows/pr-resolution.md.
+Phase 0 — re-derive shell variables. The outer orchestrator substituted
+the brace-form `${ME}` / `${OWNER}` / `${REPO}` / `${DEFAULT_BRANCH}`
+placeholders into this prompt, but several shell snippets below also
+reference `$ME` / `$OWNER` / `$REPO` as live shell variables (passed via
+`jq --arg`, used inside URLs, etc.). Re-bind them in your shell so both
+forms behave identically:
+  ME=$(gh api user -q .login)
+  OWNER=$(gh repo view --json owner -q .owner.login)
+  REPO=$(gh repo view --json name  -q .name)
+  DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+
+Read repo-local convention files BEFORE doing anything — any of these
+that exist contain standing rules that override the generic guidance in
+this prompt:
+  - AGENTS.md (project root)
+  - CLAUDE.md (project root)
+  - .github/copilot-instructions.md
+  - CONTRIBUTING.md
+  - src/object_detection/README.md (module conventions)
+
+=== Branch checkout ===
+
+  git fetch origin ${BRANCH}
+  git fetch origin ${DEFAULT_BRANCH}
+  git checkout -B local-${N} origin/${BRANCH}
+  git rebase origin/${DEFAULT_BRANCH}
+  # ...do work...
+  # ...run the pre-push gate (see below)...
+  git push --force-with-lease origin local-${N}:${BRANCH}
+
+If `git rebase origin/${DEFAULT_BRANCH}` hits a conflict whose intent is
+genuinely ambiguous after consulting code, history, and PR description,
+STOP and return blocked-conflict-ambiguous with file:line. Do not guess.
+
+=== Standing dji-tello-playground conventions ===
+
+These trump bot suggestions to the contrary — push back when bots
+violate them, citing AGENTS.md or this list:
+
+  - Commits follow Conventional Commits (`feat:`, `fix:`, `docs:`,
+    `refactor:`, `test:`, `chore:`) per AGENTS.md.
+  - Numbered exercises in `src/example_exercises/` (`NN_description.py`)
+    are deliberately self-contained teaching scripts. Some duplication
+    between exercises is intentional for readability; reusable detection
+    logic belongs in `src/object_detection/`, not forked into exercises.
+  - The `sys.path.insert(...)`-before-import pattern at the top of
+    exercises is established repo style (flake8 E402 is expected there).
+  - Drone safety is non-negotiable: scripts that can fly keep their
+    SIGINT/SIGTERM handlers and emergency-landing cleanup; RC/takeoff
+    commands stay inside `not DEBUG_MODE and not NO_TAKEOFF` guards;
+    RC velocities are clamped to [-100, 100].
+  - Tello frames arrive RGB — `cv2.cvtColor(img, cv2.COLOR_RGB2BGR)`
+    before OpenCV color operations. OpenCV hue range is 0–179.
+  - Never edit `venv/` or commit anything inside it.
+
+=== Pre-push gate (MANDATORY before every git push) ===
+
+The repo has no pre-commit config and the existing tree does not pass
+black/flake8 repo-wide, so the gate is scoped to the files this PR
+touches. Tools are pinned in requirements.txt (black, flake8, pytest).
+Run from the repo root and fix any failure before pushing:
+
+  CHANGED=$(git diff --name-only origin/${DEFAULT_BRANCH}...HEAD -- '*.py')
+  [ -n "$CHANGED" ] && black --check $CHANGED
+  [ -n "$CHANGED" ] && flake8 --max-line-length 88 --extend-ignore E203,E402 $CHANGED
+  pytest -q || [ $? -eq 5 ]   # exit 5 = "no tests collected" — fine today,
+                              # mandatory so broken tests can't ship later
+
+Never push with `--no-verify`, never skip a step, never `# noqa` away a
+flake8 finding without an inline reason. If a fix is genuinely
+out-of-scope for this PR, file a follow-up issue (see the "Filing as a
+follow-up" block below) instead of bypassing the gate. Do NOT reformat
+files the PR doesn't touch.
+
+=== Review bots (CodeRabbit + adversarial Claude review) ===
+
+Two bots review PRs here:
+
+  1. CodeRabbit — posts a walkthrough issue-comment plus inline review
+     threads. Treat its findings like any reviewer's.
+  2. The adversarial Claude reviewer (`.github/workflows/claude-code-review.yml`)
+     — runs on every non-fork PR with a valid CLAUDE_CODE_OAUTH_TOKEN
+     secret and posts an `## Adversarial review` issue comment with a
+     machine-readable `bot-review-marker` line that the Bot Blocking
+     Gate check parses. It is tuned for ZERO benefit of the doubt; the
+     correct response is **consensus, not capitulation**: fix real
+     defects, push back with evidence on hallucinated / stylistic /
+     out-of-scope findings, and resolve the thread either way. A silent
+     "done" on a wrong bot finding teaches the bot a wrong finding was
+     correct.
+
+**Wait gate after each push.** Before declaring `no-op-no-comments`,
+confirm the Claude bot has had a chance to post. Poll briefly:
+
+  gh run list --workflow=claude-code-review.yml --branch "${BRANCH}" \
+    --limit 5 --json databaseId,status,conclusion,headSha \
+    | jq -r ".[] | select(.headSha == \"$(git rev-parse HEAD)\")"
+
+If a matching run is still in-progress, wait for it to complete (or
+`gh run watch <id>`) before re-fetching comments. If no matching run
+exists after ~60s, assume the workflow's secret-gate failed (forks,
+missing secret) and proceed without it.
+
+=== Comment fetch (four channels) ===
+
+Comments live in four places. Fetch all four — silently missing one
+channel is how findings get skipped.
+
+  # 1. PR body
+  gh pr view ${N} --json body
+
+  # 2. Issue comments (conversation-tab comments — where the Claude bot
+  #    posts its `## Adversarial review` block and CodeRabbit posts its
+  #    walkthrough). --paginate is REQUIRED: gh api defaults to one page
+  #    of 30, so on a busy PR older comments are invisible.
+  gh api --paginate repos/${OWNER}/${REPO}/issues/${N}/comments
+
+  # 3. Review summaries (the bot/human "I reviewed this" bodies)
+  gh pr view ${N} --json reviews,latestReviews
+
+  # 4. Inline review comments (attached to file:line). Same pagination
+  #    rule — without --paginate the gh CLI quietly truncates.
+  gh api --paginate repos/${OWNER}/${REPO}/pulls/${N}/comments
+
+Review bodies and issue comments have **no `isResolved` field** — they
+are not modelled as review threads, so the GraphQL `reviewThreads`
+query in the resolution step below will never report state for them.
+Track them manually: read every body in full, decide a verdict per the
+table below, and reply on the parent review / issue comment when
+pushing back or confirming a fix. This is the easiest class of feedback
+to silently drop after one pass.
+
+=== Verdict per finding (MANDATORY for every comment) ===
+
+Every comment is a hypothesis until you verify it. The goal of the loop
+is **consensus on real defects**, not perpetual disagreement — and not
+capitulation by default either.
+
+For each finding:
+
+  1. Re-read the cited file at the cited line. Reviewers hallucinate
+     file contents, misread types, and quote code that was already
+     removed earlier in the same PR. `Read` the actual file before
+     forming an opinion. If the quoted snippet doesn't match the tree,
+     the comment is almost certainly a false positive.
+  2. Check the comment against repo docs (AGENTS.md, README.md,
+     src/object_detection/README.md). A comment that contradicts those
+     is itself a defect.
+  3. Pick a verdict and act:
+
+| Verdict | Action |
+|---------|--------|
+| Valid, not yet fixed | Implement fix, push, reply with commit SHA / file:line, then resolve |
+| Valid, already fixed in this PR | Reply with the commit SHA / file:line that fixed it, then resolve |
+| False positive (hallucination) | Reply quoting the real code that disproves the comment, then resolve |
+| Correct fact, wrong conclusion (by design) | Reply citing the invariant (doc path, standing convention, file:line), then resolve |
+| Stylistic preference, not a defect | Reply briefly with the rationale for the existing choice, then resolve |
+| Duplicate of an earlier addressed finding | Reply `"addressed in <prior-reply-URL>"`, then resolve |
+| `SUSPECT` flagged by reviewer | Investigate; promote to one of the rows above based on what you find. Never resolve a `SUSPECT` thread on faith. |
+
+=== EVERY finding gets a reply, EVERY thread gets resolved ===
+
+Even no-action findings need a trace. The user audits this skill's
+output by scrolling the PR's Conversation tab and looking for
+unresolved threads or silent comments. A finding you investigated and
+decided to no-op on is indistinguishable from a finding you never read
+unless you leave a trace. The bar is: "did the agent at least look at
+this?" must be answerable by reading the PR's Conversation tab alone.
+
+  - No silent agreement. A reply of "done" on an invalid comment teaches
+    the bot's knowledge base that a wrong finding was correct.
+  - No silent disagreement. If you don't fix a comment, the reply must
+    explain why with a citation.
+  - Reply first, then resolve. Always. The thread should never be
+    resolved before the reply lands.
+  - Body-channel acknowledgements (review bodies, issue comments) are
+    doubly important because there's no `isResolved` field to fall back
+    on — name each finding by quote or file:line in your acknowledgement.
+
+=== "Filing as a follow-up" means actually filing an issue ===
+
+If a reply defers an item ("tracked as a follow-up", "out of scope for
+this PR"), you MUST create a GitHub issue for it *before posting the
+reply*, then cite the issue number in the reply. Issue body opens with
+`Deferred from #${N} (<PR-comment-URL>).` and has 2-4 lines covering
+what, where (file:line), why deferred, and success criteria.
+
+Issue creation uses `gh issue create` with `--title <scope>: <one-line
+ask>` and `--body` passed via a HEREDOC (inline `--body "..."` mangles
+newlines). Then in your reply on the PR, append the single line:
+
+  Follow-up filed: #<new-issue> (<one-line scope>)
+
+=== Idempotent posting — never double-post ack comments ===
+
+Before POSTing any ack comment, check the same channel you're about to
+post on for an authored comment in the last 60 seconds with a matching
+**full body** (not a prefix). If a match exists, skip the POST and
+extract `.html_url` from that comment for any downstream reference.
+
+`gh api --jq` accepts only a single filter string and does NOT proxy
+jq's `--arg`, so the check goes through a real `jq` invocation:
+
+  existing=$(gh api --paginate "repos/${OWNER}/${REPO}/issues/${N}/comments?per_page=100" \
+    | jq -s 'add' \
+    | jq -r --arg me "$ME" --arg body "$reply_body" \
+        '[.[] | select(.user.login == $me and .body == $body
+          and ((.created_at | fromdateiso8601) > (now - 60)))][0].html_url // empty')
+  [ -n "$existing" ] && echo "duplicate; reusing $existing" && return
+
+Same shape with the path swapped for the inline-comments channel
+(`pulls/${N}/comments`) and the review-bodies channel
+(`pulls/${N}/reviews`).
+
+=== Thread resolution (GraphQL) ===
+
+Replying via the REST `/comments/<id>/replies` endpoint does NOT mark
+the thread resolved. Track the specific thread IDs you replied to and
+resolve only those — do not bulk-resolve all unresolved threads, since
+that would silently close findings you never addressed.
+
+First, page through every review thread so you can map each inline
+comment ID you replied to back to its parent thread ID. `reviewThreads`
+uses Relay cursors; paginate until `hasNextPage` is false:
+
+  gh api graphql -f query='
+    query($owner:String!,$repo:String!,$n:Int!,$cursor:String){
+      repository(owner:$owner,name:$repo){
+        pullRequest(number:$n){
+          reviewThreads(first:100, after:$cursor){
+            pageInfo{ hasNextPage endCursor }
+            nodes{ id isResolved comments(first:100){ nodes{ databaseId } } }
+          }
+        }
+      }
+    }' -F owner="$OWNER" -F repo="$REPO" -F n="$N" \
+     [ -F cursor=<endCursor from previous page> ]
+
+Build a `comment_id -> thread_id` map from the paged results. For each
+inline comment you actually replied to in this run (track `REPLIED_IDS`
+as you post), look up its `thread_id`, dedupe, and resolve only those:
+
+  for tid in $RESOLVED_THREAD_IDS; do
+    gh api graphql -f query='mutation($threadId:ID!){
+      resolveReviewThread(input:{threadId:$threadId}){thread{id isResolved}}
+    }' -f threadId="$tid"
+  done
+
+Re-fetch the same paginated query at the end as a verification step.
+Every thread ID in `RESOLVED_THREAD_IDS` must show `isResolved: true`.
+Threads you intentionally left open should be called out in `Notes`.
+
+=== Pushing ===
+
+Run the pre-push gate above. Then:
+
+  git push --force-with-lease origin local-${N}:${BRANCH}
+
+Do NOT wait for CI. Return immediately after the push so the
+orchestrator can move on. CI babysitting belongs to the circle-back
+round.
+
+Return EXACTLY this report shape (one fenced block):
+  PR: #${N}
+  Outcome: <pushed-waiting-CI | no-op-no-comments | blocked-<reason> | already-merged>
+  SHA: <pushed sha or '-'>
+  Resolved threads: <list of URLs or thread IDs, or '-'>
+  Push-backs: <one line per intentionally rejected comment with the reason, or '-'>
+  Notes: <one line, anything the orchestrator needs for the final merge-order decision>
+
+Keep the report under 250 words. `merged-ready` is NOT a first-pass
+outcome — after pushing, CI has not yet run; the earliest a PR reaches
+`merged-ready` is in a circle-back round after CI lands green.
 ```
 
-For circle-back rounds, prepend:
+### What the outer orchestrator does between fan-out and reporting
+
+- Do **not** poll the agents. With `run_in_background: true` on every dispatch, each agent fires a completion notification when done and the orchestrator's turn is re-invoked.
+- **On each completion notification, if the queue still has PRs, dispatch one replacement Agent** before accumulating the report, so the in-flight count stays ≈`MAX_CONCURRENT`. Skipping this step collapses the run back to "one batch of 4, then idle".
+- Do **not** check CI yourself for pushed PRs. The agents pushed and returned without waiting; circle-back is its own round of fan-out.
+- When **all** agents have reported (queue empty AND no in-flight Agents), assemble the merge order (see "Final report" below) from their `Outcome` + `Notes` fields. Carry each PR's reported `SHA` forward — the circle-back round will need it injected as `${PREV_SHA}` so the per-PR agent matches the right CI run.
+
+## Circle-back phase (parallel fan-out, same shape as first pass)
+
+After the first-pass reports come back, identify PRs with **open work**: CI still running or failing on the pushed SHA, new bot comments landed since the push, or threads still unresolved. **Fan out again with the same cap=4 + backfill pattern as the first pass.** Each call uses `isolation: "worktree"` and `run_in_background: true`. Use the same Per-PR Agent prompt template plus the additions below.
+
+For each circle-back invocation, the orchestrator MUST inject `${PREV_SHA}` (the SHA the first-pass agent reported for that PR) so the new agent matches the correct CI run rather than re-deriving the SHA from a moved branch. Prepend to the prompt:
 
 ```text
-Previous push SHA for this PR: ${PREV_SHA}. Use this SHA when matching the CI
-run from the prior pass.
+Previous push SHA for this PR: ${PREV_SHA}. Use this SHA when matching
+the CI run from the prior pass.
 ```
 
-## Cleanup
+1. **New comments since last push.** Re-fetch the four channels and the `claude-code-review.yml` workflow status (the bot re-runs on every push and usually posts within a minute or two of the run completing). Diff against the `Notes` snapshot in the previous round's report. Apply the same verdict logic.
 
-Follow the "Cleanup" section of `docs/agent-workflows/pr-resolution.md` (the
-all-or-nothing skip rule and discovery commands). Map the reaping step to
-Claude's `/cleanup-worktrees` and `/cleanup-branches` skills — invoke them only
-when NO PR in the run is `blocked-<reason>`.
+2. **CI status for `${PREV_SHA}`** — the per-PR agent runs:
 
-## Final Reporting
+   ```bash
+   gh run list --branch "${BRANCH}" --limit 10 \
+     --json databaseId,name,status,conclusion,headSha \
+     | jq -r ".[] | select(.headSha == \"${PREV_SHA}\")"
+   ```
 
-After all first-pass and circle-back work completes, report the merge order and
-blocked PRs using the rules in `docs/agent-workflows/pr-resolution.md`.
+   Match on `${PREV_SHA}`, not `git rev-parse HEAD` — the branch may have moved between rounds. Treat `claude-code-review.yml` `conclusion=success` as "bot review posted, fetch and address" rather than "PR is green".
+
+3. **Failures by category:**
+
+   | Failure | Action |
+   |---|---|
+   | **Test (pytest)** | Read the failing output, diagnose root cause. Fix the code if the code is wrong; fix the test only if the new behavior matches the PR's business intent. Never skip or delete a test to make CI green. |
+   | **Lint (flake8)** | Re-run the gate's flake8 line locally on the changed files, fix every reported issue. Don't `# noqa` without an inline reason. |
+   | **Format (black)** | `black <changed files>` then re-stage. |
+   | **Bot review (Claude or CodeRabbit)** | Apply the verdict table; fix real defects, push back with evidence on hallucinated / stylistic / out-of-scope findings. |
+   | **Bot Blocking Gate** | Failing means the latest adversarial review on the head SHA reported `blocking>0` (or the review hasn't completed). Address the blocking findings and push; the gate re-evaluates automatically. |
+   | **Flaky** | Rerun once. If it keeps failing intermittently, treat it as a real failure and investigate. |
+
+4. **Same push policy.** Before pushing the fix, rebase on `origin/${DEFAULT_BRANCH}` again, re-run the pre-push gate, then `git push --force-with-lease`. Resolve any threads you addressed via the GraphQL mutation.
+
+5. **Repeat the circle-back** by re-fanning out over the still-open PRs until every PR is mergeable: no conflicts, all required checks green, all threads resolved. Each round is its own parallel fan-out under the same `MAX_CONCURRENT` cap.
+
+6. **Genuine blocker → stop and surface it.** If an Agent returns `blocked-<reason>` for ambiguous conflict, CI failure with no clear cause after honest investigation, or two comments that contradict each other where neither matches the PR's business intent, surface the blocker in the final report with the specific PR number, the failing check or thread URL, and what was already tried. Do not re-dispatch the same PR with the same prompt hoping for a different answer.
+
+## Final report
+
+Once every PR in scope is mergeable, restore your starting branch (`[ "$ORIGINAL_BRANCH" = "HEAD" ] || git checkout "$ORIGINAL_BRANCH"`) and print the **merge order** the user should use. Order by:
+
+1. **Dependency chain first.** If PR B's branch was cut from PR A's branch, or PR B's diff overlaps with files PR A touches, A merges first.
+2. **Smallest blast radius next.** Among PRs with no dependencies, merge the one that touches the fewest files first.
+
+Justify the order briefly (1 short sentence per PR pair).
+
+If any PR ended the run in a blocked state, list it separately at the bottom with the blocker and *do not* include it in the merge order.
+
+## Ground rules (recap)
+
+- **Outer orchestrator never touches branches.** Enumerate, fan out, collect reports, print merge order. That's it.
+- **At most 4 Agents per message, with backfill on completion** (`MAX_CONCURRENT = 4`). Each call uses `isolation: "worktree"` AND `run_in_background: true`. Never dispatch the whole queue at once.
+- **Skip PRs whose branch is already checked out in another worktree** — mark `blocked-active-worktree`.
+- **Reply + resolve on every finding, even no-action ones.** A silent skip is indistinguishable from a missed comment.
+- **Wait for the `claude-code-review.yml` run to complete before declaring no-comments.**
+- **Pre-push gate is scoped to changed files** (`black --check` + `flake8 --max-line-length 88 --extend-ignore E203,E402` + `pytest -q`, treating "no tests collected" as pass). Mandatory before every push, never bypassed.
+- **"Filing as a follow-up" means actually filing an issue.**
+- Scope is strict: open PRs authored by `$ME` only. No exceptions.
+- If you're going to push, rebase on `origin/${DEFAULT_BRANCH}` first. Never `git merge` the default branch into a feature branch.
+- No-op PRs (no unresolved comments, no conflicts, bot run already complete and clean) are left alone. No rebase, no push, no CI burn.
+- Always `--force-with-lease`, never `--force`.
+- When two comments conflict, choose what fits the PR's business requirements and reply on the thread you didn't follow.
+- Never bypass a check by disabling, skipping, or deleting tests / lint rules / required status checks.
+- Pipeline across PRs: each per-PR Agent pushes and returns without waiting for CI; circle-back is its own round of fan-out.
+- When in doubt — stop and ask. Don't guess.
+
+## See also
+
+- [local-pr-review](../local-pr-review/SKILL.md) — run the adversarial reviewer ↔ implementer loop locally before pushing.
+- [.claude/prompts/adversarial_reviewer.md](../../prompts/adversarial_reviewer.md) and [.claude/prompts/adversarial_implementer.md](../../prompts/adversarial_implementer.md) — the two prompt bodies.
+- [.github/workflows/claude-code-review.yml](../../../.github/workflows/claude-code-review.yml) — the adversarial Claude reviewer that posts on every non-fork PR with a valid `CLAUDE_CODE_OAUTH_TOKEN` secret.
+- [.github/workflows/bot-blocking-gate.yml](../../../.github/workflows/bot-blocking-gate.yml) — the required check that enforces `blocking=0` on the head SHA.
+- [AGENTS.md](../../../AGENTS.md) — repo conventions (commit format, PR policy, drone safety).

--- a/.github/workflows/bot-blocking-gate.yml
+++ b/.github/workflows/bot-blocking-gate.yml
@@ -1,0 +1,382 @@
+name: Bot Blocking Gate
+
+# Required status check: fails when any bot adversarial review on the
+# PR's CURRENT head SHA reports a non-zero `blocking=` count without a
+# later review on the SAME head SHA superseding it with `blocking=0`.
+#
+# The motivating defect: bot reviews are submitted as `COMMENTED`, not
+# `REQUEST_CHANGES`, so the "Blocking" findings the reviewer prompt in
+# `claude-code-review.yml` is told to emit have no enforcement at the
+# GitHub layer — the PR remains mergeable. Branch protection can't
+# require a bot account as a reviewer either. This workflow is a status
+# check that branch protection CAN require, and it parses the bots'
+# existing output format.
+#
+# Architecture:
+#
+#   1. Triggers
+#      - `pull_request_target` for the initial fail-closed verdict on
+#        every push (synchronize) and PR open/reopen.
+#      - `workflow_run` on Claude Code Review completion. This fires
+#        regardless of comment authorship (issue_comment is suppressed
+#        for GITHUB_TOKEN-authored comments) AND uses the workflow
+#        definition from main, so a hot-fix to this file takes effect
+#        immediately for every subsequent bot-review completion event
+#        without requiring a per-PR push.
+#      - `issue_comment` is intentionally NOT a trigger: it never fires
+#        for the bot's marker comment (authored by GITHUB_TOKEN), and
+#        even when it did fire (e.g. a human edit) the run was filed
+#        under main's SHA so the PR's rollup never saw the result.
+#
+#   2. Verdict reporting
+#      The job does NOT rely on the workflow's own auto-generated
+#      check-run. Instead it explicitly POSTs a `Bot Blocking Gate`
+#      check-run keyed to the PR head SHA via
+#      `POST /repos/{owner}/{repo}/check-runs`. GitHub's rollup tracks
+#      the latest check-run by `(name, head_sha)`, so this is the
+#      semantic branch protection actually grades against — independent
+#      of which event triggered the run or which SHA GitHub auto-filed
+#      the run under.
+#
+#      Branch protection must require the check named `Bot Blocking
+#      Gate` (the POST'd check-run name), not `gate` (the job name).
+#
+#   3. Self-status
+#      The job itself always exits 0 unless an infrastructure error
+#      prevents it from POSTing a verdict. The verdict lives in the
+#      POST'd check-run, not the job's exit code. This prevents stale
+#      workflow-status check-runs from sticking on the PR.
+#
+# Bots covered: claude[bot] (this repo's adversarial reviewer). Copilot
+# and CodeRabbit don't emit the machine-readable marker today — they're
+# advisory, not gated.
+
+on:
+  # `pull_request_target` (not `pull_request`) so the workflow runs in
+  # the base repo's context with a writable GITHUB_TOKEN even for fork
+  # PRs. The gate POSTs a check-run, which requires `checks: write` —
+  # under `pull_request` from a fork the token is read-only and the
+  # POST would 403, leaving fork PRs with no verdict at all. This
+  # workflow never checks out PR code or executes anything from the
+  # PR's source tree (it only calls `gh api`), so the usual
+  # `pull_request_target` footgun (running untrusted code with
+  # elevated permissions) does not apply.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  # Claude Code Review posts its marker comment via the workflow's
+  # GITHUB_TOKEN, and events authored by GITHUB_TOKEN do not trigger
+  # downstream workflows. `workflow_run` fires regardless of the
+  # comment's authorship, so the gate reliably re-evaluates once the
+  # review job finishes. It also runs from the default branch's
+  # workflow definition, so a fix to this file applies to every
+  # subsequent re-fire without per-PR pushes.
+  workflow_run:
+    workflows: ["Claude Code Review"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  actions: read
+  # Required to POST the verdict check-run to the PR's head SHA via
+  # POST /repos/{owner}/{repo}/check-runs. Without this scope the
+  # explicit check-run write would silently 403 and the PR rollup would
+  # never see the verdict.
+  checks: write
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR head SHA + fork status
+        id: head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # `pull_request_target` carries the PR head SHA on the event
+          # payload; `workflow_run` carries `workflow_run.pull_requests[]`
+          # for same-repo PRs and we fall back to a SHA → PR lookup for
+          # forks. If neither yields an open PR the source run wasn't
+          # PR-associated (manual dispatch, branch push, etc.) — skip
+          # cleanly rather than failing closed.
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            pr_num=$(jq -r '.workflow_run.pull_requests[0].number // empty' \
+              "$GITHUB_EVENT_PATH")
+            review_run_id=$(jq -r '.workflow_run.id' "$GITHUB_EVENT_PATH")
+            review_head_sha=$(jq -r '.workflow_run.head_sha' "$GITHUB_EVENT_PATH")
+            if [[ -z "$pr_num" ]]; then
+              pr_num=$(gh api \
+                "repos/${{ github.repository }}/commits/${review_head_sha}/pulls" \
+                --jq '[.[] | select(.state == "open")][0].number // empty')
+            fi
+            if [[ -z "$pr_num" ]]; then
+              echo "::notice::workflow_run not associated with an open PR; nothing to gate."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "review_run_id=$review_run_id" >> "$GITHUB_OUTPUT"
+          else
+            pr_num="${{ github.event.pull_request.number }}"
+            echo "review_run_id=" >> "$GITHUB_OUTPUT"
+          fi
+          gh pr view "$pr_num" --repo "${{ github.repository }}" \
+            --json headRefOid,headRepositoryOwner,isCrossRepository > pr.json
+          head_sha=$(jq -r .headRefOid pr.json)
+          is_fork=$(jq -r .isCrossRepository pr.json)
+          short=$(printf '%s' "$head_sha" | cut -c1-7)
+          # If the PR was force-pushed between the triggering
+          # workflow_run firing (which captured the SHA it reviewed)
+          # and this gate evaluating, the run we captured is for a
+          # stale SHA. Forget its id so the next step does a fresh
+          # head_sha-keyed lookup and grades the current head SHA, not
+          # the one the bot reviewed before the push landed.
+          if [[ -n "${review_head_sha:-}" && "$review_head_sha" != "$head_sha" ]]; then
+            echo "::notice::workflow_run captured ${review_head_sha} but PR head is now ${head_sha}; ignoring stale review_run_id."
+            echo "review_run_id=" >> "$GITHUB_OUTPUT"
+          fi
+          echo "pr=$pr_num" >> "$GITHUB_OUTPUT"
+          echo "sha=$head_sha" >> "$GITHUB_OUTPUT"
+          echo "short=$short" >> "$GITHUB_OUTPUT"
+          echo "is_fork=$is_fork" >> "$GITHUB_OUTPUT"
+          echo "PR #$pr_num head: $head_sha ($short) fork=$is_fork"
+
+      - name: Check whether claude-code-review ran for this SHA
+        id: review_workflow
+        if: steps.head.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ steps.head.outputs.sha }}
+          REVIEW_RUN_ID: ${{ steps.head.outputs.review_run_id }}
+        run: |
+          set -euo pipefail
+          # Distinguishes "bot legitimately skipped" (fork PR with no
+          # CLAUDE_CODE_OAUTH_TOKEN — secrets-gate emits ok=false and
+          # claude-review is skipped at the job level) from "bot should
+          # have run but its comment is missing" (which is a malfunction
+          # the gate must fail on, not silently pass).
+          #
+          # On workflow_run we know the exact triggering run id. On
+          # pull_request_target we look up the latest run for this head
+          # SHA.
+          if [[ -n "$REVIEW_RUN_ID" ]]; then
+            run_id="$REVIEW_RUN_ID"
+          else
+            # GitHub returns workflow runs newest-first; we want the
+            # latest (rerun or most recent push) so we sort by
+            # `created_at` descending and take the first id rather than
+            # relying on response order. `last` here would pick the
+            # OLDEST run for this SHA, which on a rerun reads stale
+            # status/conclusion and can misclassify the skip /
+            # in_progress cases.
+            run_id=$(gh api --paginate \
+              "repos/${{ github.repository }}/actions/workflows/claude-code-review.yml/runs?head_sha=${SHA}&per_page=10" \
+              --jq '[.workflow_runs[]] | sort_by(.created_at) | reverse | .[0].id // empty')
+          fi
+
+          if [[ -z "$run_id" ]]; then
+            status="none"
+            conclusion="none"
+            review_job_conclusion="none"
+          else
+            run_json=$(gh api "repos/${{ github.repository }}/actions/runs/${run_id}")
+            status=$(jq -r '.status // "none"' <<< "$run_json")
+            conclusion=$(jq -r '.conclusion // "none"' <<< "$run_json")
+            # The workflow-level conclusion is `success` even when
+            # secrets-gate suppresses claude-review (the gate job itself
+            # succeeds and just emits ok=false). To detect the
+            # legitimate-skip case we must inspect the `claude-review`
+            # JOB's conclusion, not the workflow's. `skipped` here means
+            # "secrets-gate said no" (fork PR / missing secret).
+            review_job_conclusion=$(gh api --paginate \
+              "repos/${{ github.repository }}/actions/runs/${run_id}/jobs?per_page=100" \
+              --jq '[.jobs[] | select(.name == "claude-review")][0].conclusion // "none"')
+          fi
+          echo "Claude Code Review run on $SHA: status=$status workflow_conclusion=$conclusion claude_review_job_conclusion=$review_job_conclusion"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
+          echo "review_job_conclusion=$review_job_conclusion" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch latest bot adversarial review on head SHA
+        id: scan
+        if: steps.head.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.head.outputs.pr }}
+          SHORT: ${{ steps.head.outputs.short }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Adversarial reviews are posted as issue comments (`gh pr comment`
+          # under the hood). Each carries the marker:
+          #   <!-- bot-review-marker: claude blocking=N nonblocking=N suspect=N sha=<short> -->
+          # Pull all issue comments authored by claude[bot], filter to the
+          # ones whose marker matches the current head SHA short, then keep
+          # the LATEST one — bots re-review on force-push, and the most
+          # recent verdict for this SHA is the one that counts.
+          # No `|| true` here: a `gh api` failure (rate-limit, auth, outage)
+          # propagates and fails the step, which fails the gate. Silently
+          # treating an API error as "no markers found" would be an
+          # enforcement bypass.
+          gh api --paginate \
+            "repos/${REPO}/issues/${PR}/comments?per_page=100" \
+            --jq '[.[] | select(.user.login == "claude[bot]"
+                                and (.body | startswith("<!-- bot-review-marker:")))]
+                  | sort_by(.created_at)
+                  | .[]
+                  | {created_at, body: (.body | split("\n")[0])}' \
+            > all-markers.json
+
+          if [[ ! -s all-markers.json ]]; then
+            echo "verdict=no-marker" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Latest marker on this exact head SHA.
+          latest=$(jq -rs --arg short "$SHORT" \
+            '[.[] | select(.body | test("sha=" + $short + "\\b"))] | last // empty | .body' \
+            all-markers.json)
+
+          if [[ -z "$latest" ]]; then
+            echo "verdict=stale-marker" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Latest marker on $SHORT: $latest"
+          # Anchor on a non-letter before `blocking=` so the regex doesn't
+          # match the `nonblocking=` substring elsewhere in the marker.
+          # A greedy `.*blocking=([0-9]+)` would return the count from
+          # `nonblocking=` and red-fail PRs that should pass.
+          blocking=$(printf '%s' "$latest" | grep -oP '(?<![a-zA-Z])blocking=\K[0-9]+' | head -1)
+          if [[ -z "$blocking" ]]; then
+            echo "verdict=malformed-marker" >> "$GITHUB_OUTPUT"
+            echo "marker=$latest" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "verdict=parsed" >> "$GITHUB_OUTPUT"
+          echo "blocking=$blocking" >> "$GITHUB_OUTPUT"
+          echo "marker=$latest" >> "$GITHUB_OUTPUT"
+
+      - name: Decide verdict
+        id: decide
+        if: steps.head.outputs.skip != 'true'
+        env:
+          VERDICT: ${{ steps.scan.outputs.verdict }}
+          BLOCKING: ${{ steps.scan.outputs.blocking }}
+          MARKER: ${{ steps.scan.outputs.marker }}
+          SHORT: ${{ steps.head.outputs.short }}
+          IS_FORK: ${{ steps.head.outputs.is_fork }}
+          REVIEW_STATUS: ${{ steps.review_workflow.outputs.status }}
+          REVIEW_CONCLUSION: ${{ steps.review_workflow.outputs.conclusion }}
+          REVIEW_JOB_CONCLUSION: ${{ steps.review_workflow.outputs.review_job_conclusion }}
+        run: |
+          set -euo pipefail
+          # Decision matrix → emit (conclusion, title, summary) consumed
+          # by the "Post check-run" step below. Every branch here emits
+          # `success` or `failure`; `neutral` is part of the Checks API
+          # enum but we intentionally don't use it (a transient bot
+          # state is still a closed gate until the rerun lands). We
+          # never use the workflow's own exit code to gate; the POST'd
+          # check-run carries the verdict.
+          #
+          #   parsed + blocking=0   → success
+          #   parsed + blocking>0   → failure
+          #   malformed-marker      → failure (bot misfire)
+          #   no-marker / stale-marker:
+          #     - claude-review JOB conclusion == skipped → success by
+          #       absence (fork PR / no secret)
+          #     - workflow status in {queued, in_progress, waiting} →
+          #       failure (transient; will self-heal via workflow_run)
+          #     - any other shape → failure closed
+          conclusion="failure"
+          title="Unknown verdict"
+          summary=""
+          case "$VERDICT" in
+            parsed)
+              if (( BLOCKING > 0 )); then
+                conclusion="failure"
+                title="${BLOCKING} blocking finding(s) on ${SHORT}"
+                summary="Bot adversarial review on \`${SHORT}\` reports **${BLOCKING}** blocking finding(s). Address them and push, or have the bot re-review with \`blocking=0\`.\n\nMarker: \`${MARKER}\`"
+              else
+                conclusion="success"
+                title="No blocking findings on ${SHORT}"
+                summary="Bot adversarial review on \`${SHORT}\` reports 0 blocking findings; gate passes.\n\nMarker: \`${MARKER}\`"
+              fi
+              ;;
+            malformed-marker)
+              conclusion="failure"
+              title="Malformed bot review marker on ${SHORT}"
+              summary="Bot review marker present but \`blocking=\` unparseable. Marker: \`${MARKER}\`"
+              ;;
+            no-marker|stale-marker)
+              if [[ "$REVIEW_JOB_CONCLUSION" == "skipped" ]]; then
+                conclusion="success"
+                title="Claude Code Review skipped on ${SHORT}"
+                summary="The \`claude-review\` job was skipped on \`${SHORT}\` (secrets-gate emitted \`ok=false\` — typical for fork PRs without \`CLAUDE_CODE_OAUTH_TOKEN\`). Gate passes by absence."
+              elif [[ "$IS_FORK" == "true" && "$REVIEW_STATUS" == "none" ]]; then
+                conclusion="success"
+                title="Fork PR, no Claude Code Review run on ${SHORT}"
+                summary="Fork PR and Claude Code Review didn't run on \`${SHORT}\`; gate passes by absence."
+              elif [[ "$REVIEW_STATUS" == "in_progress" || "$REVIEW_STATUS" == "queued" || "$REVIEW_STATUS" == "waiting" ]]; then
+                # Word this as transient + self-healing, not a hard fail.
+                conclusion="failure"
+                title="Awaiting Claude Code Review on ${SHORT}"
+                summary="Bot Blocking Gate is failing closed because Claude Code Review is still \`${REVIEW_STATUS}\` on \`${SHORT}\`. This is expected if you just pushed — the gate will re-evaluate automatically when the review workflow completes (typically 2-5 min). No action required unless this persists past ~10 min, in which case check the Claude Code Review workflow status."
+              else
+                conclusion="failure"
+                title="No bot review marker on ${SHORT}"
+                summary="No marker for \`${SHORT}\` (Claude Code Review status=\`${REVIEW_STATUS}\` workflow_conclusion=\`${REVIEW_CONCLUSION}\` claude_review_job=\`${REVIEW_JOB_CONCLUSION}\`). Possible bot malfunction, deleted comment, or SHA mismatch — gate fails closed."
+              fi
+              ;;
+            *)
+              conclusion="failure"
+              title="Unexpected verdict on ${SHORT}"
+              summary="Unexpected scan verdict: \`${VERDICT}\`"
+              ;;
+          esac
+          echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
+          echo "title=$title" >> "$GITHUB_OUTPUT"
+          # Persist the summary as a file rather than a step output —
+          # outputs are truncated and don't survive embedded newlines.
+          printf '%b' "$summary" > /tmp/check-run-summary.txt
+          echo "Verdict: $conclusion — $title"
+
+      - name: Post check-run to PR head SHA
+        if: steps.head.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ steps.head.outputs.sha }}
+          CONCLUSION: ${{ steps.decide.outputs.conclusion }}
+          CHECK_TITLE: ${{ steps.decide.outputs.title }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # POST the verdict as a check-run keyed to the PR head SHA.
+          # This decouples the verdict from GitHub Actions' event-to-SHA
+          # mapping — `workflow_run` events file the run under main's
+          # SHA, but the check-run we POST is on the PR's head SHA, so
+          # branch protection sees it. GitHub's rollup tracks the latest
+          # check-run by (name, head_sha), which is exactly the semantic
+          # we want for "did the latest evaluation pass on this SHA?".
+          #
+          # Branch protection must require the check named "Bot Blocking
+          # Gate" (this POST), not "gate" (the job-level auto check).
+          summary=$(cat /tmp/check-run-summary.txt)
+          # Always include a link back to the workflow run so a human
+          # reading the PR check can jump to the logs.
+          summary="${summary}"$'\n\n'"[View workflow run](${RUN_URL}) — triggered by \`${EVENT_NAME}\`."
+
+          gh api -X POST "repos/${REPO}/check-runs" \
+            -f name="Bot Blocking Gate" \
+            -f head_sha="${HEAD_SHA}" \
+            -f status="completed" \
+            -f conclusion="${CONCLUSION}" \
+            -f details_url="${RUN_URL}" \
+            -f "output[title]=${CHECK_TITLE}" \
+            -f "output[summary]=${summary}" \
+            > posted-check-run.json
+          echo "Posted check-run id=$(jq -r .id posted-check-run.json) conclusion=${CONCLUSION} to ${HEAD_SHA}"

--- a/.github/workflows/bot-blocking-gate.yml
+++ b/.github/workflows/bot-blocking-gate.yml
@@ -170,9 +170,13 @@ jobs:
             # OLDEST run for this SHA, which on a rerun reads stale
             # status/conclusion and can misclassify the skip /
             # in_progress cases.
-            run_id=$(gh api --paginate \
+            # --slurp collapses the one-JSON-document-per-page output of
+            # --paginate into a single array; without it the jq filter
+            # runs per page and run_id could come back multiline once
+            # more than one page of runs exists for this SHA.
+            run_id=$(gh api --paginate --slurp \
               "repos/${{ github.repository }}/actions/workflows/claude-code-review.yml/runs?head_sha=${SHA}&per_page=10" \
-              --jq '[.workflow_runs[]] | sort_by(.created_at) | reverse | .[0].id // empty')
+              --jq '[.[].workflow_runs[]] | sort_by(.created_at) | reverse | .[0].id // empty')
           fi
 
           if [[ -z "$run_id" ]]; then
@@ -311,7 +315,12 @@ jobs:
               summary="Bot review marker present but \`blocking=\` unparseable. Marker: \`${MARKER}\`"
               ;;
             no-marker|stale-marker)
-              if [[ "$REVIEW_JOB_CONCLUSION" == "skipped" ]]; then
+              # A skipped claude-review job only counts as an authorized
+              # skip when the reviewer workflow itself succeeded (i.e.
+              # secrets-gate ran and said no). A cancelled or failed
+              # workflow also leaves the dependent job "skipped" — that
+              # must fail closed, not pass by absence.
+              if [[ "$REVIEW_JOB_CONCLUSION" == "skipped" && "$REVIEW_CONCLUSION" == "success" ]]; then
                 conclusion="success"
                 title="Claude Code Review skipped on ${SHORT}"
                 summary="The \`claude-review\` job was skipped on \`${SHORT}\` (secrets-gate emitted \`ok=false\` — typical for fork PRs without \`CLAUDE_CODE_OAUTH_TOKEN\`). Gate passes by absence."

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,20 +4,11 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-# Cancel the in-flight review when a newer push supersedes it — each run is a
-# 30-minute job, so letting stale reviews finish just burns runners.
-concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   # secrets-gate: `pull_request` runs from forks have no access to repository
   # secrets, so a job that needs CLAUDE_CODE_OAUTH_TOKEN would fail rather than
   # skip. Job-level `if:` conditions can't reference `secrets.*` directly, so we
   # check the secret here, emit an output, and gate `claude-review` on it.
-  # Until the CLAUDE_CODE_OAUTH_TOKEN secret is set on the repo this workflow is
-  # a no-op (the review job is skipped), so it is safe to merge before the token
-  # exists.
   secrets-gate:
     runs-on: ubuntu-latest
     permissions: {}
@@ -39,7 +30,6 @@ jobs:
     needs: secrets-gate
     if: ${{ needs.secrets-gate.outputs.ok == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     permissions:
       contents: read
       # write on pull-requests + issues so `gh pr comment` (issues-comments
@@ -51,9 +41,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        # Pinned to the commit SHA behind the v5 tag (v5.0.1) per the same
-        # supply-chain hardening guidance as claude-code-action below.
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        # Pinned to actions/checkout@v5; bump deliberately as a separate
+        # commit so the diff shows the version change in isolation.
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           # Don't persist GITHUB_TOKEN in .git/config: this job hands a
@@ -63,36 +53,39 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        # Pinned to the commit SHA behind the v1 tag (476e359) per GitHub
-        # Actions supply-chain hardening guidance — bump together with a
+        # Pinned to the commit SHA behind the v1 tag per GitHub Actions
+        # supply-chain hardening guidance — bump together with a
         # deliberate review.
         uses: anthropics/claude-code-action@476e359e6203e73dad705c8b322e333fabbd7416  # v1
         with:
-          # Generate via `claude setup-token` (Claude Code CLI) and store as a
-          # repo secret named CLAUDE_CODE_OAUTH_TOKEN. Rotate by re-running
-          # `setup-token` and replacing the secret.
+          # Generate via `claude setup-token` (Claude Code CLI) and store
+          # as a repo secret named CLAUDE_CODE_OAUTH_TOKEN. The token is
+          # tied to a Claude account; rotate by re-running `setup-token`
+          # and replacing the repo secret. See
+          # https://github.com/anthropics/claude-code-action#setup
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # The reviewer brief lives in .claude/prompts/adversarial_reviewer.md
-          # (vendored from RobotX-Workshops/claude-skills) so this CI run and the
-          # local /local-pr-review skill share a single source of truth. Edit the
-          # brief there, not here.
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Read the file `.claude/prompts/adversarial_reviewer.md` in this
-            checkout and follow it exactly — that is your full reviewer brief,
-            including ground rules, the categories to hunt for, the output
-            format, and the mandatory bot-review-marker line.
+            Read `.claude/prompts/adversarial_reviewer.md` in the checked
+            out repository and follow it exactly — it is the single
+            source of truth for the reviewer stance, the ground rules,
+            the hunt list, and the output format (including the
+            mandatory `bot-review-marker` first line parsed by
+            `.github/workflows/bot-blocking-gate.yml`).
 
-            After producing the review in the format that prompt specifies, use
-            `gh pr comment` with your Bash tool to post it as a comment on the
-            PR. Do not summarise, do not paraphrase, do not add a meta-preamble
-            — post the review body verbatim.
+            The diff under review is this PR's diff (`gh pr diff`).
+            Substitute `<head-sha-short>` in the marker with the 7-char
+            prefix of the PR head SHA you reviewed.
 
-          # Read/Grep/Glob let the reviewer consult CLAUDE.md / AGENTS.md /
-          # README / docs before writing the review; the gh Bash allowlist lets
-          # it read PR/issue context and post the comment. --model pins the
-          # reviewer to Haiku 4.5 to stay inside the Claude Code plan quota; bump
-          # deliberately if review quality regresses.
-          claude_args: '--model claude-haiku-4-5-20251001 --allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+            Use `gh pr comment` with your Bash tool to leave your review
+            as a comment on the PR.
+
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # for available options. Read/Grep/Glob are required because the
+          # reviewer prompt instructs consulting AGENTS.md, README.md, and
+          # src/object_detection/README.md before writing the review.
+          # Without them the reviewer can only see what `gh pr diff/view`
+          # returns, which is not enough to verify convention findings.
+          claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# Cancel the in-flight review when a newer push supersedes it — each run is a
+# 30-minute job, so letting stale reviews finish just burns runners.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   # secrets-gate: `pull_request` runs from forks have no access to repository
   # secrets, so a job that needs CLAUDE_CODE_OAUTH_TOKEN would fail rather than
@@ -30,6 +36,7 @@ jobs:
     needs: secrets-gate
     if: ${{ needs.secrets-gate.outputs.ok == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       # write on pull-requests + issues so `gh pr comment` (issues-comments
@@ -41,9 +48,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        # Pinned to actions/checkout@v5; bump deliberately as a separate
-        # commit so the diff shows the version change in isolation.
-        uses: actions/checkout@v5
+        # Pinned to the commit SHA behind the v5 tag (v5.0.1) per the same
+        # supply-chain hardening guidance as claude-code-action below.
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           fetch-depth: 1
           # Don't persist GITHUB_TOKEN in .git/config: this job hands a
@@ -88,4 +95,6 @@ jobs:
           # src/object_detection/README.md before writing the review.
           # Without them the reviewer can only see what `gh pr diff/view`
           # returns, which is not enough to verify convention findings.
-          claude_args: '--allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # --model pins the reviewer to Haiku 4.5 to stay inside the Claude
+          # Code plan quota; bump deliberately if review quality regresses.
+          claude_args: '--model claude-haiku-4-5-20251001 --allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary
Ports the agent tooling used in donkey-cars / tron-roboracer into this repo, adapted to its conventions (Conventional Commits, self-contained numbered exercises, drone-safety guards, changed-files-only lint gate):

- **`/resolve-my-prs`** (`.claude/skills/resolve-my-prs/`) — self-contained dispatch loop that fans out one worktree-isolated agent per open PR (cap 4, backfill on completion), triages every review channel (CodeRabbit, Claude bot, humans), replies to and resolves every finding, rebases + `--force-with-lease` pushes behind a lint/test gate, circles back for CI, and reports a merge order.
- **`/local-pr-review`** (`.claude/skills/local-pr-review/`) — runs the adversarial reviewer ↔ implementer loop locally in a worktree before pushing, converging on `blocking=0`.
- **`.claude/prompts/adversarial_reviewer.md` / `adversarial_implementer.md`** — shared prompt bodies (single source of truth for both CI and local runs), with a hunt list tuned for this codebase: OpenCV HSV 0–179, RGB/BGR Tello-frame confusion, `DEBUG_MODE`/`NO_TAKEOFF` guard regressions, RC velocity clamping, frame-loop hazards.
- **`.github/workflows/claude-code-review.yml`** — adversarial Claude review on every non-fork PR, posting a marker-tagged comment.
- **`.github/workflows/bot-blocking-gate.yml`** — POSTs a `Bot Blocking Gate` check-run on the PR head SHA that fails while the latest review reports `blocking>0` (fails closed, self-heals via `workflow_run`; passes by absence for fork PRs without the secret).

## Setup required after merge
1. Add the `CLAUDE_CODE_OAUTH_TOKEN` repo secret (generate with `claude setup-token`). Without it the review job skips and the gate passes by absence.
2. (Optional) In branch protection, require the check named **`Bot Blocking Gate`** to make blocking findings enforceable.

## Test plan
- YAML validated locally; workflow logic is ported verbatim from the battle-tested donkey-cars versions (only doc references, hunt list, and repo-specific issue references changed).
- After merge + secret setup, open/synchronize any PR and confirm the `## Adversarial review` comment appears and the `Bot Blocking Gate` check-run lands on the head SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786962186&installation_id=135692590&pr_number=10&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F10&signature=5d298a2ff2b288f23441b131dea18786aced963ab6303e8bb1c0a6850edc13df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Claude Code Review” automation to generate structured adversarial review feedback on pull requests.
  * Added a “Bot Blocking Gate” required status check that passes/fails based on review marker evidence tied to the current head SHA.
  * Added local workflows for running review/implementation iterations and applying fixes without pushing.
  * Added a “resolve-my-prs” workflow to grind through PRs with quality gates and constrained merge ordering.
* **Documentation**
  * Documented the review prompts, iteration convergence rules, quality checks, and PR resolution/merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->