### PR TITLE
Remove duplicate init code and unused face classifier load

### DIFF
--- a/src/example_exercises/15_circle_dectector.py
+++ b/src/example_exercises/15_circle_dectector.py
@@ -7,7 +7,6 @@ import sys
 import time
 
 import numpy as np
-from djitellopy import Tello
 
 # Set to True to use local camera for debugging, False to use drone
 DEBUG_MODE = os.getenv("DEBUG_MODE", "false").lower() == "true"
@@ -37,10 +36,6 @@ def emergency_landing(signum=None, frame=None):
     print("Cleanup complete. Exiting...")
     sys.exit(0)
 
-
-# Register signal handlers
-signal.signal(signal.SIGINT, emergency_landing)  # Ctrl+C
-signal.signal(signal.SIGTERM, emergency_landing)  # Termination signal
 
 # Register signal handlers
 signal.signal(signal.SIGINT, emergency_landing)  # Ctrl+C
@@ -358,26 +353,3 @@ while True:
 # Clean shutdown
 print("\nShutting down...")
 emergency_landing()
-
-# print("Starting flying in ...")
-# for i in range(3, 0, -1):
-#     print(i)
-#     time.sleep(1)
-
-# # Takeoff
-# print("Take off")
-# tello.take_off()
-
-# # print("Hovering for...")
-# # for i in range(3, 0, -1):
-# #     print(i)
-# #     time.sleep(1)
-# print("Height is ", tello.get_height(), "cm")
-
-
-# print("Landing")
-# # Land
-# tello.land()
-
-# End the connection
-# tello.end()

--- a/src/face_tracking/recognition_face_identifier.py
+++ b/src/face_tracking/recognition_face_identifier.py
@@ -22,7 +22,6 @@ class RecognitionFaceIdentifier(AbstractFaceIdentifier):
         model: Literal["hog", "cnn"] = "hog",
         compression_factor: int = 4,
     ):
-        self._face_cascade = open_cv.get_face_classifier()
         self.open_cv = open_cv
         self.model = model
         self.image_compression = image_compression_service


### PR DESCRIPTION
## Summary

Follow-up to #8 (which covered joysticks/face_tracking core). This pass covers the code added since then — mainly `15_circle_dectector.py` — plus one leftover memory waste in `recognition_face_identifier.py` that predates #8's scope.

- `src/example_exercises/15_circle_dectector.py`:
  - Drop the duplicated `from djitellopy import Tello` import (imported twice at module top).
  - Drop the duplicated `signal.signal(SIGINT/SIGTERM, emergency_landing)` registration block — it was registered twice back-to-back, with no effect beyond the first call.
  - Strip a ~20-line trailing block of commented-out dead flight code left over from an earlier draft.
- `src/face_tracking/recognition_face_identifier.py`:
  - Remove `self._face_cascade = open_cv.get_face_classifier()` from `__init__`. This class identifies faces via the `face_recognition` library (`identify_faces` calls `face_recognition.face_locations`), never `self._face_cascade`. The Haar cascade load (`cv2.CascadeClassifier("haarcascade_frontalface_default.xml")`) was pure wasted I/O and memory on every instantiation, doing work whose result was never used.

## Test plan

- `python3 -m py_compile` and `ast.parse` on both changed files — pass.
- `python3 -m pyflakes` on both changed files — no unused-import/unused-variable warnings.
- Confirmed via `grep` that `_face_cascade` has no other reference in `recognition_face_identifier.py`.
- No behavior change: removed code was either an exact duplicate, unreachable comments, or an assignment whose value was never read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GxvrWiFidKDv4Xe8fmA8UY)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787123887&installation_id=135692590&pr_number=11&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F11&signature=53a8b3d3a3faead1b8342aacb80389d564992b4d80cd9c8ba659cbdbc42332fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling for the circle detector, including an explicit emergency landing during termination.
  * Streamlined startup and signal handling for more predictable program behavior.

* **Maintenance**
  * Removed unused face-detection initialization while preserving existing face identification functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->