### PR TITLE
docs: fix inaccurate descriptions and expand undocumented modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `src` folder contains the core modules and components of the project. Below 
   Contains modules that act as adapters between various input devices (e.g., joysticks, keyboards) and the Tello drone control logic. These adapters standardize control inputs so the drone can interpret commands regardless of the input source. Most files primarily expose classes for use in other scripts, but also include a `__main__` block for standalone manual testing.
 
 - **[`face_tracking/`](./src/face_tracking/README.md)**  
-  Includes code for detecting and tracking faces using computer vision techniques. This module may be used for features such as autonomous following or interactive behaviors based on face detection. Most files contain classes to be used in other scripts, with the exception of `sanity_check.py`, a standalone script for testing face detection against a local webcam without a drone.
+  Includes code for detecting and tracking faces using computer vision techniques. This module may be used for features such as autonomous following or interactive behaviors based on face detection. Most files contain classes to be used in other scripts, except for `sanity_check.py`, a standalone script for testing face detection against a local webcam without a drone.
 
 - **[`object_detection/`](./src/object_detection/README.md)**  
   Houses functionality related to detecting objects in images (currently demoed on static sample images). This could be useful for obstacle avoidance, target recognition, or other advanced drone behaviors. Most files can be run directly as standalone demo scripts.
@@ -53,7 +53,18 @@ Dive into various [example exercises](./src/example_exercises) located in the `s
 Several exercises import shared modules such as `services`, `face_tracking`, and `controller_adapters`, so run them from the repository root with `src` on your `PYTHONPATH`:
 
 ```bash
+# macOS/Linux
 PYTHONPATH=src python3 ./src/<folder>/<script_name>.py
+```
+
+```bat
+:: Windows Command Prompt
+set PYTHONPATH=src && python ./src/<folder>/<script_name>.py
+```
+
+```powershell
+# Windows PowerShell
+$env:PYTHONPATH = "src"; python ./src/<folder>/<script_name>.py
 ```
 
 Replace `<script_name>` with the script you wish to run and `<folder>` with the folder/s the script is located in, e.g. `PYTHONPATH=src python3 ./src/example_exercises/2_simple_takeoff_land.py`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Welcome to the DJI Tello Drone Playground! This project is designed for enthusia
 
 ## 📡 Setup Drone Connection
 
-To interact with the drone, you must first establish a WiFi connection:
+To interact with the drone, you must first establish a WiFi connection (see the [full connection guide](./docs/setup_drone_connection.md) for the power-on button press and status-light sequence):
 
 1. Power on your DJI Tello drone.
 2. Connect your computer to the drone's WiFi network.
@@ -35,28 +35,28 @@ The `src` folder contains the core modules and components of the project. Below 
   Contains modules that act as adapters between various input devices (e.g., joysticks, keyboards) and the Tello drone control logic. These adapters standardize control inputs so the drone can interpret commands regardless of the input source. Most files primarily expose classes for use in other scripts, but also include a `__main__` block for standalone manual testing.
 
 - **[`face_tracking/`](./src/face_tracking/README.md)**  
-  Includes code for detecting and tracking faces using computer vision techniques. This module may be used for features such as autonomous following or interactive behaviors based on face detection. The files contain classes to be used in other scripts but not executed directly.
+  Includes code for detecting and tracking faces using computer vision techniques. This module may be used for features such as autonomous following or interactive behaviors based on face detection. Most files contain classes to be used in other scripts, with the exception of `sanity_check.py`, a standalone script for testing face detection against a local webcam without a drone.
 
 - **[`object_detection/`](./src/object_detection/README.md)**  
-  Houses functionality related to detecting objects within video feeds. This could be useful for obstacle avoidance, target recognition, or other advanced drone behaviors. Most files can be run directly as standalone demo scripts.
+  Houses functionality related to detecting objects in images (currently demoed on static sample images). This could be useful for obstacle avoidance, target recognition, or other advanced drone behaviors. Most files can be run directly as standalone demo scripts.
 
 - **[`joysticks/`](./src/joysticks/README.md)**  
   Contains modules for interfacing with different joystick and game controller types. This folder enables the project to support multiple controller configurations for manual drone operation. Most files primarily expose classes for use in other scripts, but also include a `__main__` block for standalone manual testing.
 
 - **[`services/`](./src/services/README.md)**  
-  Implements the core services for interacting with the Tello drone, such as establishing connections, sending commands, and managing the drone’s state. The files contain classes to be used in other scripts but not executed directly
+  Implements the core services for interacting with the Tello drone, such as establishing connections, sending commands, and managing the drone’s state. The files contain classes to be used in other scripts but not executed directly.
 
 ## 📝 Exercises
 
 Dive into various [example exercises](./src/example_exercises) located in the `src` folder. Each script guides you through different functionalities of the DJI Tello drone.
 
-To run an exercise, navigate to the [`src`](./src/)  folder and execute the corresponding script:
+Several exercises import shared modules such as `services`, `face_tracking`, and `controller_adapters`, so run them from the repository root with `src` on your `PYTHONPATH`:
 
 ```bash
-python ./<folder>/<script_name>.py
+PYTHONPATH=src python3 ./src/<folder>/<script_name>.py
 ```
 
-Replace <script_name> with the script you wish to run and <folder> with the folder/s the script is located in.
+Replace `<script_name>` with the script you wish to run and `<folder>` with the folder/s the script is located in, e.g. `PYTHONPATH=src python3 ./src/example_exercises/2_simple_takeoff_land.py`.
 
 For More info checkout the [README](./src/example_exercises/README.md)
 
@@ -93,9 +93,9 @@ If you encounter an error like `client_socket.bind(("", Tello.CONTROL_UDP_PORT))
 
 3. **Restart your computer** if the above doesn't work - this will clear all stuck processes.
 
-4. **Use debug mode** for testing without connecting to the drone:
+4. **Use debug mode** for testing without connecting to the drone. Currently only the circle-detector exercise supports this:
    ```bash
-   DEBUG_MODE=true PYTHONPATH=src python3 ./src/example_exercises/your_script.py
+   DEBUG_MODE=true PYTHONPATH=src python3 ./src/example_exercises/15_circle_dectector.py
    ```
 
 ## 🐞 Debugging with Visual Studio Code

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -1,6 +1,8 @@
 # 🎮 Controllers and Joysticks
 
-This directory contains the code for the controllers and joysticks used in the project.
+This page lists the controllers and joysticks supported by the project. See [`src/controller_adapters/`](../src/controller_adapters/README.md) and [`src/joysticks/`](../src/joysticks/README.md) for the implementation.
+
+Only Xbox 360, Wired Xbox One, and Keyboard are currently selectable via `control_via_gamepad.py --controller`; the other controllers below are run directly through their own adapter script (see their `__main__` blocks) rather than through that CLI's `auto`-detection.
 
 ## 🖥 System Support
 

--- a/docs/drone_status_indicator_states.md
+++ b/docs/drone_status_indicator_states.md
@@ -1,9 +1,18 @@
 # Drone Status Indicator States
 
-The best way to understand the different states of the drone status indicator is to see them in action. The following table lists the different states and their meanings.
+The table below lists the drone status indicator's colors and patterns and what each one means.
 
-- Blue LED: The blue LED is the main status indicator for charging states.
-- Red LED: The red LED is the main status indicator for the drone's Battery charge level.
-- Green/Yellow LED: The green/yellow and yellow states and there combination are general status indicators for the drone.
+| Category | Color | Pattern | Aircraft State |
+| --- | --- | --- | --- |
+| Normal States | Alternating red, green, and yellow | Blinking | Turning on and performing self-diagnostic tests |
+| Normal States | Green | Periodically blinks twice | Vision Positioning System active |
+| Normal States | Yellow | Blinking slowly | Vision Positioning System unavailable, aircraft is in Attitude mode |
+| Charging States | Blue | Solid | Charging is complete |
+| Charging States | Blue | Blinking slowly | Charging |
+| Charging States | Blue | Blinking quickly | Charging error |
+| Warning States | Yellow | Blinking quickly | Remote control signal lost |
+| Warning States | Red | Blinking slowly | Low battery |
+| Warning States | Red | Blinking quickly | Critically low battery |
+| Warning States | Red | Solid | Critical error |
 
-![charging_states](./images/status_indicator_states.png)
+![Drone status indicator states](./images/status_indicator_states.png)

--- a/docs/installing_vs_build_tools.md
+++ b/docs/installing_vs_build_tools.md
@@ -1,4 +1,6 @@
-# How to install Visual C++ Build tools 
+# How to install Visual C++ Build tools
+
+Required only on Windows if you plan to use the face-tracking module, which depends on `face_recognition`/`dlib` (see [`src/face_tracking/requirements.txt`](../src/face_tracking/requirements.txt)) and needs a C++ compiler to build from source.
 
 1. Download the installer [here](https://aka.ms/vs/17/release/vs_buildtools.exe)
 2. Once downloaded click on the downloaded file and open the installer 

--- a/docs/manual_control_with_smartphone.md
+++ b/docs/manual_control_with_smartphone.md
@@ -1,11 +1,12 @@
 # Manual Control with Smartphone
-   
+
 Learn how to control the drone manually using your smartphone.
 
-Lets get a feel for the drone by controlling it manually. 
+Let's get a feel for the drone by controlling it manually.
 
-1. [Download](https://www.dji.com/de/downloads/djiapp/tello) the Tello app on your smartphone and connect to the drone's WiFi network. 
-![QR Code](./images/app_qr_code.png)
-2. Open the app and you should see a live feed from the drone's camera. 
+1. [Download](https://www.dji.com/de/downloads/djiapp/tello) the Tello app on your smartphone and connect to the drone's WiFi network.
+
+    ![QR Code](./images/app_qr_code.png)
+2. Open the app and you should see a live feed from the drone's camera.
 3. You can now control the drone using the on-screen controls.
 

--- a/docs/setting_up_the_environment.md
+++ b/docs/setting_up_the_environment.md
@@ -118,7 +118,18 @@ Remember to activate the Conda environment each time you work on this project.
 Several scripts under `src/` import sibling packages such as `services`, `face_tracking`, and `controller_adapters`, so once your environment is set up, run scripts from the repository root with `src` on your `PYTHONPATH`:
 
 ```bash
+# macOS/Linux
 PYTHONPATH=src python3 ./src/<folder>/<script_name>.py
+```
+
+```bat
+:: Windows Command Prompt
+set PYTHONPATH=src && python ./src/<folder>/<script_name>.py
+```
+
+```powershell
+# Windows PowerShell
+$env:PYTHONPATH = "src"; python ./src/<folder>/<script_name>.py
 ```
 
 See the root [README](../README.md#-exercises) for more details.

--- a/docs/setting_up_the_environment.md
+++ b/docs/setting_up_the_environment.md
@@ -16,7 +16,7 @@ You can download Visual Studio Code from [this link](https://code.visualstudio.c
 
 ### Dependencies
 
-Before starting, ensure you have Python 3.11 higher.
+Before starting, ensure you have Python 3.11 installed (the project is developed and tested against 3.11).
 
 You can download from [here for Windows](https://apps.microsoft.com/detail/9nrwmjp3717k?hl=en-US&gl=US) version or the official site [here](https://www.python.org/downloads/release/python-3115/) for other platforms.
 
@@ -112,3 +112,13 @@ pip install -r requirements.txt
 ```
 
 Remember to activate the Conda environment each time you work on this project.
+
+## Running Scripts
+
+Several scripts under `src/` import sibling packages such as `services`, `face_tracking`, and `controller_adapters`, so once your environment is set up, run scripts from the repository root with `src` on your `PYTHONPATH`:
+
+```bash
+PYTHONPATH=src python3 ./src/<folder>/<script_name>.py
+```
+
+See the root [README](../README.md#-exercises) for more details.

--- a/docs/setup_drone_connection.md
+++ b/docs/setup_drone_connection.md
@@ -6,7 +6,7 @@ To interact with the drone, you must first establish a WiFi connection:
 2. Look at the aircraft status lights. It should go though the following sequence:
    - Alternating red and yellow: The drone is turning on and performing self diagnostic tests.
    - Yellow blinking quickly: The drone is not connected but is ready to connect to a WiFi network.
-   - The drone will only stay in the waiting state for a short while. Try restarting the done if it becomes unreachable why turning on and off again
+   - The drone will only stay in the waiting state for a short while. Try restarting the drone if it becomes unreachable by turning it on and off again.
 3. Connect your computer to the drone's WiFi network.
 
     ![Connecting to Tello WiFi](./images/trello_wifi.png)

--- a/src/controller_adapters/README.md
+++ b/src/controller_adapters/README.md
@@ -1,7 +1,13 @@
 # Controller Adapters
 
-This package contains adapters that adapt the output from a gamepad or other controller to the input expected by the Tello Controller.
+This package contains adapters that adapt the output from a gamepad or other controller to the input expected by the Tello Controller (`TelloControlState`, defined in [`services/`](../services/README.md)).
 
 See the "Adapter" in this image for a visual representation of the Adapter pattern:
 
 ![Adapter](../../docs/images/architechture.svg)
+
+## Files
+
+- `gc102_controller_tello_adapter.py`, `keyboard_controller.py`, `logitech_f710_tello_adapter.py`, `tectinter_tello_adapter.py`, `xbox_controller_tello_adapter.py`, `xbox_one_tello_adapter.py` — one adapter per supported input device (see [Controllers and Joysticks](../../docs/controllers.md)). Each has a `__main__` block that calls the shared `utils.run_adapter_test()` helper, so you can run any of them directly to manually test its output, e.g. `python xbox_controller_tello_adapter.py`.
+- `follow_face_controller.py` — `FaceFollowingController`, a different kind of adapter that converts a face-tracking movement vector (not joystick/gamepad input) into a `TelloControlState`. Used by `example_exercises/follow_face.py` and `mock_follow_face.py`.
+- `utils.py` — shared `run_adapter_test()` manual-test loop used by the adapter scripts above; not a standalone script.

--- a/src/example_exercises/README.md
+++ b/src/example_exercises/README.md
@@ -2,8 +2,14 @@
 
 This folder contains a collection of sample scripts and exercises designed to help you get started with and understand the functionality of the DJI Tello playground. These examples demonstrate how to use various components of the project—from basic drone commands to more advanced features like computer vision integrations.
 
-Make sure to always execute the scripts from the `src` directory to ensure proper module imports and file references.
+Run scripts from the repository root with `src` on your `PYTHONPATH`, since several exercises import sibling packages such as `services`, `face_tracking`, and `controller_adapters`:
 
-The numbered exercises are ordered from basic to advanced, with each script building upon the concepts introduced in the previous ones. Feel free to explore and modify the scripts to suit your needs or experiment with new ideas.
+```bash
+PYTHONPATH=src python3 ./src/example_exercises/<script_name>.py
+```
 
-The other scripts are more advaned and demonstrate additional capabilities of the Tello drone, such as face tracking, object detection, and autonomous flight.
+Just `cd`-ing into `src` and running a script directly is not enough — scripts like `2_simple_takeoff_land.py` will fail with `ModuleNotFoundError: No module named 'services'` without `PYTHONPATH` set.
+
+The numbered exercises are ordered from basic to advanced concepts, increasing in complexity as they go. Feel free to explore and modify the scripts to suit your needs or experiment with new ideas.
+
+The other scripts (`control_via_gamepad.py`, `follow_face.py`, `mock_follow_face.py`, `navigate_route.py`) demonstrate additional capabilities: manual gamepad/keyboard control, face tracking/following (with a `mock_follow_face.py` webcam-only variant for testing without a drone), and a starting point for autonomous route navigation. Object/circle detection is covered by the numbered exercise `15_circle_dectector.py`, which also supports a `DEBUG_MODE` environment variable to test against a local webcam instead of the drone. It also has a `NO_TAKEOFF` constant (edit the source to set it to `True`) to connect and stream from the drone without taking off.

--- a/src/example_exercises/README.md
+++ b/src/example_exercises/README.md
@@ -5,7 +5,18 @@ This folder contains a collection of sample scripts and exercises designed to he
 Run scripts from the repository root with `src` on your `PYTHONPATH`, since several exercises import sibling packages such as `services`, `face_tracking`, and `controller_adapters`:
 
 ```bash
+# macOS/Linux
 PYTHONPATH=src python3 ./src/example_exercises/<script_name>.py
+```
+
+```bat
+:: Windows Command Prompt
+set PYTHONPATH=src && python ./src/example_exercises/<script_name>.py
+```
+
+```powershell
+# Windows PowerShell
+$env:PYTHONPATH = "src"; python ./src/example_exercises/<script_name>.py
 ```
 
 Just `cd`-ing into `src` and running a script directly is not enough — scripts like `2_simple_takeoff_land.py` will fail with `ModuleNotFoundError: No module named 'services'` without `PYTHONPATH` set.

--- a/src/joysticks/README.md
+++ b/src/joysticks/README.md
@@ -2,7 +2,7 @@
 
 This package contains the low-level joystick/game controller integrations used by the [`controller_adapters/`](../controller_adapters/README.md) package to translate raw input into Tello drone commands.
 
-Each supported controller has one or more platform-specific implementations (e.g. `xbox_controller_linux.py`, `xbox_controller_mac.py`, `xbox_controller_windows.py`) behind a common wrapper (e.g. `xbox_controller.py`) that picks the right implementation for the current OS at runtime.
+Most supported controllers have one or more platform-specific implementations (e.g. `xbox_controller_linux.py`, `xbox_controller_mac.py`, `xbox_controller_windows.py`) behind a common wrapper (e.g. `xbox_controller.py`) that picks the right implementation for the current OS at runtime. A few (Logitech F710, TectInter) ship as a single cross-platform implementation instead.
 
 See [Controllers and Joysticks](../../docs/controllers.md) for the list of controllers supported on each platform.
 

--- a/src/object_detection/README.md
+++ b/src/object_detection/README.md
@@ -1,3 +1,11 @@
 # Object Detection Module
 
-This module implements basic object detection algorithms. It provides functionalities for detecting circular objects and edges in images using computer vision techniques.
+This module implements basic object detection algorithms. It provides functionality for detecting circular objects (via the Hough Circle Transform) and straight lines (via Canny edge detection + the Hough Line Transform) in images using computer vision techniques.
+
+## Files
+
+- `circles_detection.py` — `CircleDetector.detect_circles(img)` finds circles with `cv2.HoughCircles` and displays them. Run: `python src/object_detection/circles_detection.py` (uses the bundled `circles.jpg`).
+- `canny_line_detection.py` — `LineDetector.detect_lines(img)` finds straight lines with Canny edge detection + `cv2.HoughLines` and displays them. Run: `python src/object_detection/canny_line_detection.py` (uses the bundled `lines.png`).
+- `utils.py` — shared drawing/geometry helpers (`draw_object_mask`, `draw_object_box`, `get_frame_box_dimensions_delta`) used to render detector output; not a standalone script.
+
+Both demo scripts open a window and block on a keypress (`cv2.waitKey(0)`) — press any key to close it.

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,3 +1,11 @@
 # Services Module
 
-The `services` module provides the core functionality for interacting with the DJI Tello drone. It handles establishing and managing the connection, dispatching commands, and exposing control interfaces that other parts of the project can use.
+The `services` module provides the core functionality for interacting with the DJI Tello drone:
+
+- `TelloConnector` — wraps `djitellopy.Tello`; handles the connection lifecycle, movement primitives, and telemetry (battery, height, flight time, attitude, etc.).
+- `TelloCommandDispatcher` — translates a `TelloControlState` into RC control calls and discrete actions (takeoff/land/emergency-stop/flips).
+- `TelloController` (abstract base), `TelloControlState`, and `TelloActionType` — the control-interface contract that other modules (e.g. `controller_adapters/`) implement against.
+- `FrontEnd` — orchestrates the connection/dispatch/control loop and displays live video via `cv2.imshow`.
+- `TelloTV` — a minimal stub that currently just holds a `TelloConnector` reference.
+
+Files expose classes to be used by other scripts (e.g. `example_exercises/`, `controller_adapters/`) and are not executed directly — none of the files in this folder define a `__main__` block.


### PR DESCRIPTION
## Summary

Scheduled documentation audit: every README/docs file was checked line-by-line against the actual code (8 parallel research passes, several claims verified by actually running the documented commands). This fixes the inaccuracies found and expands a few modules whose docs named zero classes/files despite implementing core project logic.

Checked for existing overlapping work first — no open PR or issue covers a docs audit; open PRs #5, #9, #10 add unrelated features/tooling and don't touch these files.

### Accuracy fixes (verified against code)
- **Root `README.md` / `src/example_exercises/README.md`**: the documented exercise-run command omitted `PYTHONPATH=src`. Confirmed by actually running `2_simple_takeoff_land.py` without it → `ModuleNotFoundError: No module named 'services'`. The `DEBUG_MODE` troubleshooting example generalized a flag that only `15_circle_dectector.py` implements; also corrected the doc's implication that `NO_TAKEOFF` is an env var — it's a hardcoded constant you edit in the source.
- **`docs/drone_status_indicator_states.md`**: replaced a prose summary that mischaracterized the red LED as a pure battery gauge and invented a "green/yellow combined" state that isn't in the source image, with a real markdown table transcribed from the screenshot (also makes it accessible/searchable instead of image-only).
- **`docs/controllers.md`**: fixed "this directory contains the code" (it's a docs page, not a code directory) and noted that only Xbox 360 / Wired Xbox One / Keyboard are wired into `control_via_gamepad.py`'s CLI — the other listed controllers only run via their own adapter script.
- **`src/joysticks/README.md`**: softened the "every controller has per-OS implementation files" claim — Logitech F710 and TectInter ship as single cross-platform files.
- **`src/object_detection/README.md`**: fixed "detecting edges" (the module detects circles and straight lines; Canny is only a preprocessing step, not the output) and the root README's claim that it processes "video feeds" (both demos process static bundled images).
- **Root README**: `face_tracking/` no longer claims all files are non-executable — `sanity_check.py` is a standalone runnable script.
- **`docs/setup_drone_connection.md`, `docs/manual_control_with_smartphone.md`**: typo/grammar fixes ("the done" → "the drone", missing apostrophe, stray blank line).
- **`docs/setting_up_the_environment.md`**: "Python 3.11 higher" → "Python 3.11" (grammar), added a `PYTHONPATH` cross-reference since the doc never mentioned it despite every script needing it.
- **`docs/installing_vs_build_tools.md`**: added a sentence explaining *why* it's needed (Windows + `face_recognition`/`dlib`), since the page previously gave zero context.

### Readability / documentation-gap fixes
- **`src/services/README.md`** and **`src/controller_adapters/README.md`**: both were 3-4 line descriptions naming zero concrete classes despite implementing the project's core control-flow contract (`TelloConnector`, `TelloCommandDispatcher`, `TelloController`/`TelloControlState`/`TelloActionType`, `FrontEnd`, `TelloTV`, and the six gamepad adapters + `FaceFollowingController`). Added file/class listings.
- **`src/object_detection/README.md`**: added a Files section (previously undocumented by name) and a run-command/interaction note (`cv2.waitKey(0)` blocks on keypress).

## Not fixed here (out of scope for a docs-only change, flagged for a maintainer)
- `.devcontainer/devcontainer.json:19` maps `11111:1117/udp` instead of `11111:11111/udp` for the Tello video-stream port — looks like a typo that would break video forwarding from the dev container.
- `.vscode/settings.json`'s `python.analysis.extraPaths` hardcodes a Linux/macOS venv layout (`./venv/lib/python3.11/site-packages`), which won't resolve for Windows users following the documented Option 1 setup.
- `src/joysticks/Ioctl_joystick.py` and `keyboard_test.py` appear to be orphaned/dead code (not imported anywhere, not documented).
- `src/face_tracking/open_cv_face_identifier.py` (`OpenCvFaceIdentifier`) references a `haarcascade_frontalface_default.xml` file that doesn't exist in the repo, and is never instantiated by any script — candidate for removal.
- `src/example_exercises/15_circle_dectector.py` filename has a typo ("dectector"); left as-is since renaming would be a code change, not a docs change, and would need updating every reference to the file.

## Test plan
- [x] Verified every referenced image/relative link resolves on disk.
- [x] Verified class/function names and signatures cited in the new doc text against the actual `.py` files (`grep -n "class ..."` / `def ...`).
- [x] Reproduced the `ModuleNotFoundError` the old run-command instructions would hit, and verified the corrected `PYTHONPATH=src` command form works.
- [x] Visually reviewed `docs/images/status_indicator_states.png` to transcribe the table accurately.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E7RwshUFaU9GUtuoJwiJBf)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787469908&installation_model_id=422527&pr_number=12&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F12&signature=273b2d1510bfc29b4018e39cd994f6d5225539f3a369e1017d47807668d834c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved drone WiFi setup and troubleshooting guidance, including status-light behavior and restart steps.
  * Added clearer instructions for running exercises and scripts with the required Python environment.
  * Clarified supported controllers, adapter usage, and joystick implementation details.
  * Reorganized drone status indicators into an easier-to-read reference table.
  * Expanded documentation for controller adapters, services, example exercises, and object-detection demos.
  * Improved formatting across installation and smartphone-control guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->