### PR TITLE
perf: remove per-frame allocations and redundant frame throttling

### DIFF
--- a/src/example_exercises/15_circle_dectector.py
+++ b/src/example_exercises/15_circle_dectector.py
@@ -344,9 +344,9 @@ while True:
         tello.send_rc_control(left_right, forward_backward, up_down, -yaw)
 
     cv2.imshow("Circle Detection", img)
-    time.sleep(1 / 15)
-    # Press 'q' or ESC to quit
-    key = cv2.waitKey(1) & 0xFF
+    # Press 'q' or ESC to quit; the ~66ms wait also caps the loop to ~15 FPS,
+    # making a separate time.sleep(1 / 15) redundant.
+    key = cv2.waitKey(66) & 0xFF
     if key == ord("q") or key == 27:
         break
 

--- a/src/example_exercises/16_color_contour_detector.py
+++ b/src/example_exercises/16_color_contour_detector.py
@@ -322,8 +322,9 @@ try:
             tello.send_rc_control(0, forward_velocity, up_down_velocity, yaw_velocity)
 
         cv2.imshow(WINDOW, img)
-        time.sleep(1 / 15)
-        key = cv2.waitKey(1) & 0xFF
+        # The ~66ms wait also caps the loop to ~15 FPS, making a separate
+        # time.sleep(1 / 15) redundant.
+        key = cv2.waitKey(66) & 0xFF
         if key == ord("q") or key == 27:
             break
 

--- a/src/example_exercises/control_via_gamepad.py
+++ b/src/example_exercises/control_via_gamepad.py
@@ -74,8 +74,6 @@ def get_tello_control(controller_arg: str) -> TelloController:
             tello_controller_adapter = _CONTROLLER_ID_CLASS_MAPPING[controller_type](pygame_connector)
         except KeyError:
             raise ValueError(f"Unsupported controller type for auto detection: {controller_arg}")
-    elif controller_arg.lower() == "keyboard":
-        tello_controller_adapter = KeyboardControlAdapter(pygame_connector)
     else:
         # Auto-detect controller via joystick initialization
         try:

--- a/src/face_tracking/image_provider.py
+++ b/src/face_tracking/image_provider.py
@@ -3,8 +3,10 @@ import cv2
 
 try:
     from open_cv_wrapper import OpenCvWrapper
+    from image_compression_service import ImageCompressionService
 except ModuleNotFoundError:
     from face_tracking.open_cv_wrapper import OpenCvWrapper
+    from face_tracking.image_compression_service import ImageCompressionService
 
 LOGGER = logging.getLogger(__name__)
 
@@ -35,6 +37,7 @@ class ImageProvider:
         )
         self.compression = compression
         self.open_cv = open_cv
+        self._compression_service = ImageCompressionService(open_cv)
 
     def connect_to_camera(self, id: int = 0):
         """
@@ -58,12 +61,6 @@ class ImageProvider:
         if not self.cap.isOpened():
             raise Exception("Camera is not connected")
 
-        compression = self.compression
         _, frame = self.cap.read()
-        # Get the image height and width
 
-        compressed_image = self.open_cv.resize(
-            frame, (0, 0), fx=1 / compression, fy=1 / compression
-        )
-
-        return compressed_image
+        return self._compression_service.compress_image(frame, self.compression)

--- a/src/object_detection/color_contour_detection.py
+++ b/src/object_detection/color_contour_detection.py
@@ -119,6 +119,10 @@ class ColorContourDetector:
         frame = detector.draw(frame_bgr, detections)  # overlay boxes
     """
 
+    # Reused across every `create_mask` call instead of being reallocated
+    # per-frame - the kernel is a fixed 5x5 constant regardless of config.
+    _MORPH_KERNEL = np.ones((5, 5), np.uint8)
+
     def __init__(self, config: ColorContourConfig):
         self.config = config
 
@@ -159,9 +163,8 @@ class ColorContourDetector:
             mask = cv2.bitwise_or(mask, mask2)
 
         # Morphological open/close cleans up ragged edges and fills pinholes.
-        morph_kernel = np.ones((5, 5), np.uint8)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, morph_kernel)
-        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, morph_kernel)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, self._MORPH_KERNEL)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, self._MORPH_KERNEL)
         return mask
 
     def detect(self, img_bgr: cv2.typing.MatLike) -> List[ColorContour]:


### PR DESCRIPTION
## Summary

Small, low-risk cleanups found while auditing the codebase for speed/memory optimizations and redundant/duplicated logic. No behavior changes intended beyond the noted micro-optimizations.

- **Perf**: `ColorContourDetector.create_mask` (`src/object_detection/color_contour_detection.py`) reallocated a `5x5` `np.ones` morphology kernel on *every* video frame. Hoisted it to a class-level constant reused across calls.
- **Perf/redundancy**: `15_circle_dectector.py` and `16_color_contour_detector.py` each called `time.sleep(1 / 15)` immediately followed by `cv2.waitKey(1)` at the end of their capture loops — the sleep and the wait were both trying to throttle the loop. Collapsed into a single `cv2.waitKey(66)`, which throttles to the same ~15 FPS while still handling key presses.
- **Redundancy**: `ImageProvider.get_image` (`src/face_tracking/image_provider.py`) reimplemented the exact same `cv2.resize` compression math as `ImageCompressionService.compress_image`. It now delegates to `ImageCompressionService` instead of duplicating the logic.
- **Dead code**: `control_via_gamepad.get_tello_control` had an `elif controller_arg.lower() == "keyboard":` branch that could never execute — `GameControllerType.KEYBOARD` is already handled by the preceding `if controller_arg.lower() != "auto":` branch, so `"keyboard"` never reaches the `elif`. Removed the unreachable branch.

## Test plan

- No automated test suite covers these modules (`pytest` only currently collects an unrelated interactive pygame script, see #13); verified via `python3 -m py_compile` / `ast.parse` on all changed files.
- Confirmed via `git diff` that each change is behavior-preserving:
  - Same 5x5 kernel values, just not reallocated per frame.
  - `cv2.waitKey(66)` ≈ `1/15` s, matching the previous combined delay.
  - `ImageCompressionService.compress_image` performs the identical `cv2.resize` call `ImageProvider` used to do inline.
  - The removed `elif` branch was unreachable dead code (confirmed by tracing `_CONTROLLER_ID_CLASS_MAPPING` and the preceding `if` condition).
- Not flight-tested against physical hardware (scheduled/automated task, no drone available in this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_019BJxWigw7EfnaTonQ81pRM)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787728913&installation_model_id=422527&pr_number=15&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F15&signature=bdff18bcd1e653082904265797d6de9789d4c508189dabb586c7b7a76bd283a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved video exercise timing and keyboard event handling while preserving `q` and `ESC` exit controls.
  - Invalid controller selections now provide a clear error instead of unexpectedly falling back to keyboard control.
  - Image capture now applies consistent compression behavior.
  - Color contour detection benefits from smoother repeated mask processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->