### PR TITLE
chore: dedupe gamepad adapter logic and fix camera resource leaks

### DIFF
--- a/src/controller_adapters/base_gamepad_adapter.py
+++ b/src/controller_adapters/base_gamepad_adapter.py
@@ -1,0 +1,61 @@
+from typing import List
+
+from services.tello_controller import (
+    TelloActionType,
+    TelloControlState,
+    TelloController,
+)
+
+
+class BaseGamepadTelloAdapter(TelloController):
+    """Shared button/axis-mapping logic for the standard gamepad layout.
+
+    Every supported controller (Xbox, Xbox One, GC102, Logitech F710,
+    TectInter) exposes the same `get_state()` shape via its `PyGameController`,
+    so the Tello button/axis mapping below is identical across adapters.
+    """
+
+    def __init__(self, controller):
+        self.controller = controller
+
+    def t(self, controller_axis_value: float) -> int:
+        "Transform the controller axis value to the tello control value"
+        return int(controller_axis_value * 100)
+
+    def get_state(self) -> TelloControlState:
+        controller_state = self.controller.get_state()
+
+        pressed_buttons = controller_state.buttons.get_pressed_buttons()
+        d_pad = controller_state.d_pad
+
+        events: List[TelloActionType] = []
+        if "Y" in pressed_buttons:
+            events.append(TelloActionType.TAKEOFF)
+        if "A" in pressed_buttons:
+            events.append(TelloActionType.LAND)
+        if "B" in pressed_buttons:
+            events.append(TelloActionType.EMERGENCY_LAND)
+
+        if d_pad.vertical_up == 1:
+            events.append(TelloActionType.FLIP_FORWARD)
+        if d_pad.vertical_up == -1:
+            events.append(TelloActionType.FLIP_BACK)
+        if d_pad.horizontal_right == -1:
+            events.append(TelloActionType.FLIP_LEFT)
+        if d_pad.horizontal_right == 1:
+            events.append(TelloActionType.FLIP_RIGHT)
+
+        if "RB" in pressed_buttons:
+            events.append(TelloActionType.INCREASE_SPEED_CM_S)
+        if "LB" in pressed_buttons:
+            events.append(TelloActionType.DECREASE_SPEED_CM_S)
+
+        t = self.t
+
+        return TelloControlState(
+            forward_velocity=t(-controller_state.axes.left_stick.vertical_down),
+            right_velocity=t(controller_state.axes.left_stick.horizontal_right),
+            up_velocity=t(-controller_state.axes.right_stick.vertical_down),
+            yaw_right_velocity=t(controller_state.axes.right_stick.horizontal_right),
+            events=events,
+        )

--- a/src/controller_adapters/base_gamepad_adapter.py
+++ b/src/controller_adapters/base_gamepad_adapter.py
@@ -1,10 +1,15 @@
-from typing import List
+from typing import Protocol
 
+from joysticks.game_controller_type import GameControllerState
 from services.tello_controller import (
     TelloActionType,
     TelloControlState,
     TelloController,
 )
+
+
+class GamepadController(Protocol):
+    def get_state(self) -> GameControllerState: ...
 
 
 class BaseGamepadTelloAdapter(TelloController):
@@ -15,7 +20,7 @@ class BaseGamepadTelloAdapter(TelloController):
     so the Tello button/axis mapping below is identical across adapters.
     """
 
-    def __init__(self, controller):
+    def __init__(self, controller: GamepadController) -> None:
         self.controller = controller
 
     def t(self, controller_axis_value: float) -> int:
@@ -28,7 +33,7 @@ class BaseGamepadTelloAdapter(TelloController):
         pressed_buttons = controller_state.buttons.get_pressed_buttons()
         d_pad = controller_state.d_pad
 
-        events: List[TelloActionType] = []
+        events: list[TelloActionType] = []
         if "Y" in pressed_buttons:
             events.append(TelloActionType.TAKEOFF)
         if "A" in pressed_buttons:

--- a/src/controller_adapters/gc102_controller_tello_adapter.py
+++ b/src/controller_adapters/gc102_controller_tello_adapter.py
@@ -5,64 +5,15 @@ script_dir = os.path.dirname(__file__)
 parent_dir = os.path.join(script_dir, "..")
 sys.path.append(parent_dir)
 
-from typing import List
-
 from joysticks.gc102_controller import GC102PyGameController
 from joysticks.pygame_connector import PyGameConnector
-from services.tello_controller import (
-    TelloActionType,
-    TelloControlState,
-    TelloController,
-)
+from .base_gamepad_adapter import BaseGamepadTelloAdapter
 from .utils import run_adapter_test
 
 
-class GC102TelloControlAdapter(TelloController):
-
+class GC102TelloControlAdapter(BaseGamepadTelloAdapter):
     def __init__(self, controller: GC102PyGameController):
-        self.gc102_controller = controller
-
-    def t(self, controller_axis_value: float) -> int:
-        "Transform the controller axis value to the tello control value"
-        return int(controller_axis_value * 100)
-
-    def get_state(self) -> TelloControlState:
-        controller_state = self.gc102_controller.get_state()
-
-        pressed_buttons = controller_state.buttons.get_pressed_buttons()
-        d_pad = controller_state.d_pad
-
-        events: List[TelloActionType] = []
-        if "Y" in pressed_buttons:
-            events.append(TelloActionType.TAKEOFF)
-        if "A" in pressed_buttons:
-            events.append(TelloActionType.LAND)
-        if "B" in pressed_buttons:
-            events.append(TelloActionType.EMERGENCY_LAND)
-
-        if d_pad.vertical_up == 1:
-            events.append(TelloActionType.FLIP_FORWARD)
-        if d_pad.vertical_up == -1:
-            events.append(TelloActionType.FLIP_BACK)
-        if d_pad.horizontal_right == -1:
-            events.append(TelloActionType.FLIP_LEFT)
-        if d_pad.horizontal_right == 1:
-            events.append(TelloActionType.FLIP_RIGHT)
-
-        if "RB" in pressed_buttons:
-            events.append(TelloActionType.INCREASE_SPEED_CM_S)
-        if "LB" in pressed_buttons:
-            events.append(TelloActionType.DECREASE_SPEED_CM_S)
-
-        t = self.t
-
-        return TelloControlState(
-            forward_velocity=t(-controller_state.axes.left_stick.vertical_down),
-            right_velocity=t(controller_state.axes.left_stick.horizontal_right),
-            up_velocity=t(-controller_state.axes.right_stick.vertical_down),
-            yaw_right_velocity=t(controller_state.axes.right_stick.horizontal_right),
-            events=events,
-        )
+        super().__init__(controller)
 
 
 if __name__ == "__main__":

--- a/src/controller_adapters/gc102_controller_tello_adapter.py
+++ b/src/controller_adapters/gc102_controller_tello_adapter.py
@@ -12,7 +12,7 @@ from .utils import run_adapter_test
 
 
 class GC102TelloControlAdapter(BaseGamepadTelloAdapter):
-    def __init__(self, controller: GC102PyGameController):
+    def __init__(self, controller: GC102PyGameController) -> None:
         super().__init__(controller)
 
 

--- a/src/controller_adapters/logitech_f710_tello_adapter.py
+++ b/src/controller_adapters/logitech_f710_tello_adapter.py
@@ -12,7 +12,7 @@ from .utils import run_adapter_test
 
 
 class LogitechF710ControlAdapter(BaseGamepadTelloAdapter):
-    def __init__(self, controller: LogitechF710Joystick):
+    def __init__(self, controller: LogitechF710Joystick) -> None:
         super().__init__(controller)
 
 

--- a/src/controller_adapters/logitech_f710_tello_adapter.py
+++ b/src/controller_adapters/logitech_f710_tello_adapter.py
@@ -5,63 +5,15 @@ script_dir = os.path.dirname(__file__)
 parent_dir = os.path.join(script_dir, "..")
 sys.path.append(parent_dir)
 
-from typing import List
 from src.joysticks.logitech_f710_controller import LogitechF710Joystick
-from services.tello_controller import (
-    TelloActionType,
-    TelloControlState,
-    TelloController,
-)
 from joysticks.pygame_connector import PyGameConnector
+from .base_gamepad_adapter import BaseGamepadTelloAdapter
 from .utils import run_adapter_test
 
 
-class LogitechF710ControlAdapter(TelloController):
-
+class LogitechF710ControlAdapter(BaseGamepadTelloAdapter):
     def __init__(self, controller: LogitechF710Joystick):
-        self.xbox_controller = controller
-
-    def t(self, controller_axis_value: float) -> int:
-        "Transform the controller axis value to the tello control value"
-        return int(controller_axis_value * 100)
-
-    def get_state(self) -> TelloControlState:
-        controller_state = self.xbox_controller.get_state()
-
-        pressed_buttons = controller_state.buttons.get_pressed_buttons()
-        d_pad = controller_state.d_pad
-
-        events: List[TelloActionType] = []
-        if "Y" in pressed_buttons:
-            events.append(TelloActionType.TAKEOFF)
-        if "A" in pressed_buttons:
-            events.append(TelloActionType.LAND)
-        if "B" in pressed_buttons:
-            events.append(TelloActionType.EMERGENCY_LAND)
-
-        if d_pad.vertical_up == 1:
-            events.append(TelloActionType.FLIP_FORWARD)
-        if d_pad.vertical_up == -1:
-            events.append(TelloActionType.FLIP_BACK)
-        if d_pad.horizontal_right == -1:
-            events.append(TelloActionType.FLIP_LEFT)
-        if d_pad.horizontal_right == 1:
-            events.append(TelloActionType.FLIP_RIGHT)
-
-        if "RB" in pressed_buttons:
-            events.append(TelloActionType.INCREASE_SPEED_CM_S)
-        if "LB" in pressed_buttons:
-            events.append(TelloActionType.DECREASE_SPEED_CM_S)
-
-        t = self.t
-
-        return TelloControlState(
-            forward_velocity=t(-controller_state.axes.left_stick.vertical_down),
-            right_velocity=t(controller_state.axes.left_stick.horizontal_right),
-            up_velocity=t(-controller_state.axes.right_stick.vertical_down),
-            yaw_right_velocity=t(controller_state.axes.right_stick.horizontal_right),
-            events=events,
-        )
+        super().__init__(controller)
 
 
 if __name__ == "__main__":

--- a/src/controller_adapters/tectinter_tello_adapter.py
+++ b/src/controller_adapters/tectinter_tello_adapter.py
@@ -5,65 +5,15 @@ script_dir = os.path.dirname(__file__)
 parent_dir = os.path.join(script_dir, "..")
 sys.path.append(parent_dir)
 
-from typing import List
-
 from joysticks.tectinter_controller_windows import TectInterJoystick
-
-from services.tello_controller import (
-    TelloActionType,
-    TelloControlState,
-    TelloController,
-)
 from joysticks.pygame_connector import PyGameConnector
+from .base_gamepad_adapter import BaseGamepadTelloAdapter
 from .utils import run_adapter_test
 
 
-class TectInterJoystickControlAdapter(TelloController):
-
+class TectInterJoystickControlAdapter(BaseGamepadTelloAdapter):
     def __init__(self, controller: TectInterJoystick):
-        self.xbox_controller = controller
-
-    def t(self, controller_axis_value: float) -> int:
-        "Transform the controller axis value to the tello control value"
-        return int(controller_axis_value * 100)
-
-    def get_state(self) -> TelloControlState:
-        controller_state = self.xbox_controller.get_state()
-
-        pressed_buttons = controller_state.buttons.get_pressed_buttons()
-        d_pad = controller_state.d_pad
-
-        events: List[TelloActionType] = []
-        if "Y" in pressed_buttons:
-            events.append(TelloActionType.TAKEOFF)
-        if "A" in pressed_buttons:
-            events.append(TelloActionType.LAND)
-        if "B" in pressed_buttons:
-            events.append(TelloActionType.EMERGENCY_LAND)
-
-        if d_pad.vertical_up == 1:
-            events.append(TelloActionType.FLIP_FORWARD)
-        if d_pad.vertical_up == -1:
-            events.append(TelloActionType.FLIP_BACK)
-        if d_pad.horizontal_right == -1:
-            events.append(TelloActionType.FLIP_LEFT)
-        if d_pad.horizontal_right == 1:
-            events.append(TelloActionType.FLIP_RIGHT)
-
-        if "RB" in pressed_buttons:
-            events.append(TelloActionType.INCREASE_SPEED_CM_S)
-        if "LB" in pressed_buttons:
-            events.append(TelloActionType.DECREASE_SPEED_CM_S)
-
-        t = self.t
-
-        return TelloControlState(
-            forward_velocity=t(-controller_state.axes.left_stick.vertical_down),
-            right_velocity=t(controller_state.axes.left_stick.horizontal_right),
-            up_velocity=t(-controller_state.axes.right_stick.vertical_down),
-            yaw_right_velocity=t(controller_state.axes.right_stick.horizontal_right),
-            events=events,
-        )
+        super().__init__(controller)
 
 
 if __name__ == "__main__":

--- a/src/controller_adapters/tectinter_tello_adapter.py
+++ b/src/controller_adapters/tectinter_tello_adapter.py
@@ -12,7 +12,7 @@ from .utils import run_adapter_test
 
 
 class TectInterJoystickControlAdapter(BaseGamepadTelloAdapter):
-    def __init__(self, controller: TectInterJoystick):
+    def __init__(self, controller: TectInterJoystick) -> None:
         super().__init__(controller)
 
 

--- a/src/controller_adapters/xbox_controller_tello_adapter.py
+++ b/src/controller_adapters/xbox_controller_tello_adapter.py
@@ -5,64 +5,15 @@ script_dir = os.path.dirname(__file__)
 parent_dir = os.path.join(script_dir, "..")
 sys.path.append(parent_dir)
 
-from typing import List
 from joysticks.pygame_connector import PyGameConnector
 from joysticks.xbox_controller import XboxPyGameController
-
-from services.tello_controller import (
-    TelloActionType,
-    TelloControlState,
-    TelloController,
-)
+from .base_gamepad_adapter import BaseGamepadTelloAdapter
 from .utils import run_adapter_test
 
 
-class XboxTelloControlAdapter(TelloController):
-
+class XboxTelloControlAdapter(BaseGamepadTelloAdapter):
     def __init__(self, controller: XboxPyGameController):
-        self.xbox_controller = controller
-
-    def t(self, controller_axis_value: float) -> int:
-        "Transform the controller axis value to the tello control value"
-        return int(controller_axis_value * 100)
-
-    def get_state(self) -> TelloControlState:
-        controller_state = self.xbox_controller.get_state()
-
-        pressed_buttons = controller_state.buttons.get_pressed_buttons()
-        d_pad = controller_state.d_pad
-
-        events: List[TelloActionType] = []
-        if "Y" in pressed_buttons:
-            events.append(TelloActionType.TAKEOFF)
-        if "A" in pressed_buttons:
-            events.append(TelloActionType.LAND)
-        if "B" in pressed_buttons:
-            events.append(TelloActionType.EMERGENCY_LAND)
-
-        if d_pad.vertical_up == 1:
-            events.append(TelloActionType.FLIP_FORWARD)
-        if d_pad.vertical_up == -1:
-            events.append(TelloActionType.FLIP_BACK)
-        if d_pad.horizontal_right == -1:
-            events.append(TelloActionType.FLIP_LEFT)
-        if d_pad.horizontal_right == 1:
-            events.append(TelloActionType.FLIP_RIGHT)
-
-        if "RB" in pressed_buttons:
-            events.append(TelloActionType.INCREASE_SPEED_CM_S)
-        if "LB" in pressed_buttons:
-            events.append(TelloActionType.DECREASE_SPEED_CM_S)
-
-        t = self.t
-
-        return TelloControlState(
-            forward_velocity=t(-controller_state.axes.left_stick.vertical_down),
-            right_velocity=t(controller_state.axes.left_stick.horizontal_right),
-            up_velocity=t(-controller_state.axes.right_stick.vertical_down),
-            yaw_right_velocity=t(controller_state.axes.right_stick.horizontal_right),
-            events=events,
-        )
+        super().__init__(controller)
 
 
 if __name__ == "__main__":

--- a/src/controller_adapters/xbox_controller_tello_adapter.py
+++ b/src/controller_adapters/xbox_controller_tello_adapter.py
@@ -12,7 +12,7 @@ from .utils import run_adapter_test
 
 
 class XboxTelloControlAdapter(BaseGamepadTelloAdapter):
-    def __init__(self, controller: XboxPyGameController):
+    def __init__(self, controller: XboxPyGameController) -> None:
         super().__init__(controller)
 
 

--- a/src/controller_adapters/xbox_one_tello_adapter.py
+++ b/src/controller_adapters/xbox_one_tello_adapter.py
@@ -5,64 +5,15 @@ script_dir = os.path.dirname(__file__)
 parent_dir = os.path.join(script_dir, "..")
 sys.path.append(parent_dir)
 
-from typing import List
 from joysticks.pygame_connector import PyGameConnector
 from joysticks.xbox_one_controller import XboxOnePyGameController
-from services.tello_controller import (
-    TelloActionType,
-    TelloControlState,
-    TelloController,
-)
-
+from .base_gamepad_adapter import BaseGamepadTelloAdapter
 from .utils import run_adapter_test
 
 
-class XboxOneTelloControlAdapter(TelloController):
-
+class XboxOneTelloControlAdapter(BaseGamepadTelloAdapter):
     def __init__(self, controller: XboxOnePyGameController):
-        self.xbox_controller = controller
-
-    def t(self, controller_axis_value: float) -> int:
-        "Transform the controller axis value to the tello control value"
-        return int(controller_axis_value * 100)
-
-    def get_state(self) -> TelloControlState:
-        controller_state = self.xbox_controller.get_state()
-
-        pressed_buttons = controller_state.buttons.get_pressed_buttons()
-        d_pad = controller_state.d_pad
-
-        events: List[TelloActionType] = []
-        if "Y" in pressed_buttons:
-            events.append(TelloActionType.TAKEOFF)
-        if "A" in pressed_buttons:
-            events.append(TelloActionType.LAND)
-        if "B" in pressed_buttons:
-            events.append(TelloActionType.EMERGENCY_LAND)
-
-        if d_pad.vertical_up == 1:
-            events.append(TelloActionType.FLIP_FORWARD)
-        if d_pad.vertical_up == -1:
-            events.append(TelloActionType.FLIP_BACK)
-        if d_pad.horizontal_right == -1:
-            events.append(TelloActionType.FLIP_LEFT)
-        if d_pad.horizontal_right == 1:
-            events.append(TelloActionType.FLIP_RIGHT)
-
-        if "RB" in pressed_buttons:
-            events.append(TelloActionType.INCREASE_SPEED_CM_S)
-        if "LB" in pressed_buttons:
-            events.append(TelloActionType.DECREASE_SPEED_CM_S)
-
-        t = self.t
-
-        return TelloControlState(
-            forward_velocity=t(-controller_state.axes.left_stick.vertical_down),
-            right_velocity=t(controller_state.axes.left_stick.horizontal_right),
-            up_velocity=t(-controller_state.axes.right_stick.vertical_down),
-            yaw_right_velocity=t(controller_state.axes.right_stick.horizontal_right),
-            events=events,
-        )
+        super().__init__(controller)
 
 
 if __name__ == "__main__":

--- a/src/controller_adapters/xbox_one_tello_adapter.py
+++ b/src/controller_adapters/xbox_one_tello_adapter.py
@@ -12,7 +12,7 @@ from .utils import run_adapter_test
 
 
 class XboxOneTelloControlAdapter(BaseGamepadTelloAdapter):
-    def __init__(self, controller: XboxOnePyGameController):
+    def __init__(self, controller: XboxOnePyGameController) -> None:
         super().__init__(controller)
 
 

--- a/src/example_exercises/3_drone_information.py
+++ b/src/example_exercises/3_drone_information.py
@@ -1,7 +1,5 @@
 from djitellopy import Tello
 
-import time
-
 from services.tello_connector import TelloConnector
 
 # Create a Tello instance

--- a/src/example_exercises/follow_face.py
+++ b/src/example_exercises/follow_face.py
@@ -131,6 +131,7 @@ while True:
         break
 
 tello_service.streamoff()
+cv2.destroyAllWindows()
 
 LOGGER.info("Landing")
 # Land

--- a/src/example_exercises/mock_follow_face.py
+++ b/src/example_exercises/mock_follow_face.py
@@ -117,3 +117,6 @@ while True:
 
     if open_cv.listen_for_key(1) & 0xFF == ord("q"):
         break
+
+cam.release()
+cv2.destroyAllWindows()


### PR DESCRIPTION
## Summary

Follow-up to #8, #11, and #15's automated speed/memory + redundancy passes. Checked open PRs/issues first (only #10, unrelated "PR-resolution skills" work, is open — no overlap) so this doesn't duplicate in-flight work.

- **Redundancy (biggest find)**: `src/controller_adapters/{xbox_controller,xbox_one,gc102_controller,logitech_f710,tectinter}_tello_adapter.py` each reimplemented a byte-for-byte identical `get_state()`/`t()` — the same button→`TelloActionType` mapping (Y=TAKEOFF, A=LAND, B=EMERGENCY_LAND, d-pad→flips, RB/LB→speed) and axis transform, verified with `diff` across all 5 files. Extracted into a new shared `BaseGamepadTelloAdapter` (`src/controller_adapters/base_gamepad_adapter.py`); each adapter now just subclasses it with a typed constructor. Removes ~250 duplicated lines and means future button-mapping fixes only need to happen once.
- **Resource leak**: `mock_follow_face.py` never called `cam.release()`/`cv2.destroyAllWindows()` after its capture loop, unlike every other camera script in the repo (`sanity_check.py`, `15_circle_dectector.py`, `16_color_contour_detector.py`), leaking the webcam handle on exit. Added the same cleanup.
- **Consistency**: `follow_face.py` called `streamoff()` on exit but never `cv2.destroyAllWindows()`, unlike its sibling scripts. Added it.
- **Dead code**: `3_drone_information.py` imported `time` but never used it. Removed.

Deliberately left alone (flagged in #8 as needing a human call, not a mechanical fix, and still true): `print_state()` duplicated across ~9 joystick `__main__` blocks, and the duplicated font-scaling formula in `image_drawing_service.py`/`object_detection/utils.py` — both have slightly different surrounding defaults where unification requires a product decision.

## Verification

- `python3 -m py_compile` on all changed/added files.
- `python3 -m pyflakes` on all changed/added files — clean.
- Live import of all 5 refactored adapter modules with `pygame`/`opencv-python`/`djitellopy` installed — all succeed.
- Behavioral equivalence check: instantiated `XboxTelloControlAdapter` with a stubbed controller (fixed button/axis/d-pad state) and confirmed `get_state()` output matches what the original inline logic would have produced (`TAKEOFF` + `FLIP_FORWARD` + `INCREASE_SPEED_CM_S` events, correct velocity values).
- `black --check` on new/changed files — clean (two pre-existing, unrelated formatting issues in `follow_face.py`/`mock_follow_face.py` predate this change and are out of scope).
- Not flight-tested against physical hardware (scheduled/automated task, no drone available in this environment).


---
_Generated by [Claude Code](https://claude.ai/code/session_01XUjfFLhzCV5YpW6V3otjmT)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788333948&installation_model_id=422527&pr_number=17&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F17&signature=5fefcba8654e4dfa6df89296e8ef7b0f3e49b33e417a9d3488245ca3572feee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared gamepad controls for drone movement, takeoff, landing, emergency landing, flips, and speed adjustments.
  * Standardized controller behavior across supported gamepads and joysticks.

* **Bug Fixes**
  * Improved cleanup in face-following examples by releasing the camera and closing video windows when finished.

* **Chores**
  * Removed an unused import from the drone information example.
  * Simplified controller-specific implementations while preserving existing controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->