### PR TITLE
chore: dedupe joystick print_state and face-tracking loop, fix sanity_check leak

### DIFF
--- a/src/example_exercises/follow_face.py
+++ b/src/example_exercises/follow_face.py
@@ -6,15 +6,10 @@ from face_tracking.image_drawing_service import ImageDrawingService
 from face_tracking.image_compression_service import ImageCompressionService
 from face_tracking.recognition_face_identifier import RecognitionFaceIdentifier
 from face_tracking.open_cv_wrapper import OpenCvWrapper
+from face_tracking.tracking_frame_processor import process_tracking_frame
 from djitellopy import Tello
 import logging
 import argparse
-from face_tracking.utils.positioning_utils import (
-    get_box_center_xyz,
-    get_distance_xyz,
-    get_frame_center_xy,
-    get_vector_xyz,
-)
 from services.tello_command_dispatcher import TelloCommandDispatcher
 from services.tello_connector import TelloConnector
 from controller_adapters.follow_face_controller import FaceFollowingController
@@ -71,59 +66,11 @@ while True:
         LOGGER.debug("No frame")
         continue
 
-    faces_trbl = face_identifier.identify_faces(frame)
-    if not faces_trbl:
-        LOGGER.debug("No faces")
+    control_state = process_tracking_frame(
+        frame, face_identifier, image_drawer, controller, open_cv, DEPTH_TARGET, LOGGER
+    )
+    if control_state is None:
         continue
-
-    frame_center_xyz = (*get_frame_center_xy(frame), DEPTH_TARGET)
-
-    closest = None
-    for face_trbl in faces_trbl:
-        box_center = get_box_center_xyz(face_trbl, DEPTH_TARGET)
-        distance = get_distance_xyz(frame_center_xyz, box_center)
-        if closest is None or distance < closest[1]:
-            closest = (face_trbl, distance, box_center)
-        frame = image_drawer.draw_box(
-            frame,
-            face_trbl,
-            "green",
-        )
-        frame = image_drawer.draw_cross_hair_in_box(frame, face_trbl, 4, "green")
-
-    assert closest is not None
-    closest_box = closest[0]
-    closest_distance = closest[1]
-    closest_center = closest[2]
-
-    vector_to_center = get_vector_xyz(frame_center_xyz, closest_center)
-
-    frame = image_drawer.draw_box(frame, closest_box, "red")
-    frame = image_drawer.draw_frame_center_cross_hair(frame, 2, 20, "red")
-
-    LOGGER.debug(
-        f"Closest face at {frame_center_xyz, closest_center} with distance {closest_distance}"
-    )
-
-    control_state = controller.get_state(vector_to_center)
-    height, width = frame.shape[:2]
-    bottom = height - 10
-    left = 10
-
-    # Write the control state information on the frame
-    open_cv.write_text(
-        frame,
-        f"Forward: {control_state.forward_velocity},"
-        f"Move Right: {control_state.right_velocity}, "
-        f"Up: {control_state.up_velocity}, "
-        f"Yaw Right: {control_state.yaw_right_velocity}",
-        (left, bottom),
-        cv2.FONT_HERSHEY_DUPLEX,
-        0.5,  # Adjust the font scale as needed
-        (255, 255, 255),
-        1,
-    )
-    open_cv.show_image("frame", frame)
 
     dispatcher.send_commands(control_state)
 

--- a/src/example_exercises/mock_follow_face.py
+++ b/src/example_exercises/mock_follow_face.py
@@ -10,14 +10,9 @@ from face_tracking.image_drawing_service import ImageDrawingService
 from face_tracking.image_compression_service import ImageCompressionService
 from face_tracking.recognition_face_identifier import RecognitionFaceIdentifier
 from face_tracking.open_cv_wrapper import OpenCvWrapper
+from face_tracking.tracking_frame_processor import process_tracking_frame
 import logging
 import argparse
-from face_tracking.utils.positioning_utils import (
-    get_box_center_xyz,
-    get_distance_xyz,
-    get_frame_center_xy,
-    get_vector_xyz,
-)
 from controller_adapters.follow_face_controller import FaceFollowingController
 
 
@@ -59,59 +54,11 @@ while True:
         LOGGER.debug("No frame")
         continue
 
-    faces_trbl = face_identifier.identify_faces(frame)
-    if not faces_trbl:
-        LOGGER.debug("No faces")
+    control_state = process_tracking_frame(
+        frame, face_identifier, image_drawer, controller, open_cv, DEPTH_TARGET, LOGGER
+    )
+    if control_state is None:
         continue
-
-    frame_center_xyz = (*get_frame_center_xy(frame), DEPTH_TARGET)
-
-    closest = None
-    for face_trbl in faces_trbl:
-        box_center = get_box_center_xyz(face_trbl, DEPTH_TARGET)
-        distance = get_distance_xyz(frame_center_xyz, box_center)
-        if closest is None or distance < closest[1]:
-            closest = (face_trbl, distance, box_center)
-        frame = image_drawer.draw_box(
-            frame,
-            face_trbl,
-            "green",
-        )
-        frame = image_drawer.draw_cross_hair_in_box(frame, face_trbl, 4, "green")
-
-    assert closest is not None
-    closest_box = closest[0]
-    closest_distance = closest[1]
-    closest_center = closest[2]
-
-    vector_to_center = get_vector_xyz(frame_center_xyz, closest_center)
-
-    frame = image_drawer.draw_box(frame, closest_box, "red")
-    frame = image_drawer.draw_frame_center_cross_hair(frame, 2, 20, "red")
-
-    LOGGER.debug(
-        f"Closest face at {frame_center_xyz, closest_center} with distance {closest_distance}"
-    )
-
-    control_state = controller.get_state(vector_to_center)
-    height, width = frame.shape[:2]
-    bottom = height - 10
-    left = 10
-
-    # Write the control state information on the frame
-    open_cv.write_text(
-        frame,
-        f"Forward: {control_state.forward_velocity},"
-        f"Move Right: {control_state.right_velocity}, "
-        f"Up: {control_state.up_velocity}, "
-        f"Yaw Right: {control_state.yaw_right_velocity}",
-        (left, bottom),
-        cv2.FONT_HERSHEY_DUPLEX,
-        0.5,  # Adjust the font scale as needed
-        (255, 255, 255),
-        1,
-    )
-    open_cv.show_image("frame", frame)
 
     # dispatcher.send_commands(control_state)
 

--- a/src/face_tracking/sanity_check.py
+++ b/src/face_tracking/sanity_check.py
@@ -12,6 +12,7 @@ from image_drawing_service import ImageDrawingService
 from image_compression_service import ImageCompressionService
 from recognition_face_identifier import RecognitionFaceIdentifier
 from open_cv_wrapper import OpenCvWrapper
+import cv2
 import logging
 import argparse
 from utils.positioning_utils import (
@@ -93,3 +94,4 @@ while True:
         break
 
 cam.release()
+cv2.destroyAllWindows()

--- a/src/face_tracking/tracking_frame_processor.py
+++ b/src/face_tracking/tracking_frame_processor.py
@@ -52,11 +52,13 @@ def process_tracking_frame(
     frame = image_drawer.draw_frame_center_cross_hair(frame, 2, 20, "red")
 
     logger.debug(
-        f"Closest face at {frame_center_xyz, closest_center} with distance {closest_distance}"
+        "Closest face at %s with distance %s",
+        (frame_center_xyz, closest_center),
+        closest_distance,
     )
 
     control_state = controller.get_state(vector_to_center)
-    height, width = frame.shape[:2]
+    height = frame.shape[0]
     bottom = height - 10
     left = 10
 

--- a/src/face_tracking/tracking_frame_processor.py
+++ b/src/face_tracking/tracking_frame_processor.py
@@ -63,7 +63,7 @@ def process_tracking_frame(
     # Write the control state information on the frame
     open_cv.write_text(
         frame,
-        f"Forward: {control_state.forward_velocity},"
+        f"Forward: {control_state.forward_velocity}, "
         f"Move Right: {control_state.right_velocity}, "
         f"Up: {control_state.up_velocity}, "
         f"Yaw Right: {control_state.yaw_right_velocity}",

--- a/src/face_tracking/tracking_frame_processor.py
+++ b/src/face_tracking/tracking_frame_processor.py
@@ -1,0 +1,78 @@
+"""Shared per-frame face-tracking logic used by follow_face.py and mock_follow_face.py."""
+
+import logging
+
+import cv2
+
+from face_tracking.utils.positioning_utils import (
+    get_box_center_xyz,
+    get_distance_xyz,
+    get_frame_center_xy,
+    get_vector_xyz,
+)
+
+
+def process_tracking_frame(
+    frame,
+    face_identifier,
+    image_drawer,
+    controller,
+    open_cv,
+    depth_target: int,
+    logger: logging.Logger,
+):
+    """Identify faces in `frame`, draw the tracking overlays, and return the
+    controller's control state for the closest face, or None if no face was found.
+    """
+    faces_trbl = face_identifier.identify_faces(frame)
+    if not faces_trbl:
+        logger.debug("No faces")
+        return None
+
+    frame_center_xyz = (*get_frame_center_xy(frame), depth_target)
+
+    closest = None
+    for face_trbl in faces_trbl:
+        box_center = get_box_center_xyz(face_trbl, depth_target)
+        distance = get_distance_xyz(frame_center_xyz, box_center)
+        if closest is None or distance < closest[1]:
+            closest = (face_trbl, distance, box_center)
+        frame = image_drawer.draw_box(
+            frame,
+            face_trbl,
+            "green",
+        )
+        frame = image_drawer.draw_cross_hair_in_box(frame, face_trbl, 4, "green")
+
+    closest_box, closest_distance, closest_center = closest
+
+    vector_to_center = get_vector_xyz(frame_center_xyz, closest_center)
+
+    frame = image_drawer.draw_box(frame, closest_box, "red")
+    frame = image_drawer.draw_frame_center_cross_hair(frame, 2, 20, "red")
+
+    logger.debug(
+        f"Closest face at {frame_center_xyz, closest_center} with distance {closest_distance}"
+    )
+
+    control_state = controller.get_state(vector_to_center)
+    height, width = frame.shape[:2]
+    bottom = height - 10
+    left = 10
+
+    # Write the control state information on the frame
+    open_cv.write_text(
+        frame,
+        f"Forward: {control_state.forward_velocity},"
+        f"Move Right: {control_state.right_velocity}, "
+        f"Up: {control_state.up_velocity}, "
+        f"Yaw Right: {control_state.yaw_right_velocity}",
+        (left, bottom),
+        cv2.FONT_HERSHEY_DUPLEX,
+        0.5,  # Adjust the font scale as needed
+        (255, 255, 255),
+        1,
+    )
+    open_cv.show_image("frame", frame)
+
+    return control_state

--- a/src/joysticks/gc102_controller.py
+++ b/src/joysticks/gc102_controller.py
@@ -54,19 +54,16 @@ class GC102PyGameController(GameController):
 if __name__ == "__main__":
     import os
 
+    try:
+        from joysticks.utils import print_state
+    except ModuleNotFoundError:
+        from utils import print_state
+
     log_level = logging.INFO
     logging.basicConfig(level=log_level)
     _LOGGER.setLevel(log_level)
     pygame_connector = PyGameConnector()
     pygame_joystick = GC102PyGameController(pygame_connector)
-
-    def print_state(state_dict: dict, indent=""):
-        for k, v in state_dict.items():
-            if isinstance(v, dict):
-                print(f"{indent}{k}:")
-                print_state(v, indent + "  ")
-            else:
-                print(f"{indent}{k}: {v}")
 
     while True:
         os.system("cls" if os.name == "nt" else "clear")  # Clear the console

--- a/src/joysticks/gc102_controller_windows.py
+++ b/src/joysticks/gc102_controller_windows.py
@@ -199,19 +199,16 @@ class WindowsGC102PyGameJoystick(GameController):
 if __name__ == "__main__":
     import os
 
+    try:
+        from joysticks.utils import print_state
+    except ModuleNotFoundError:
+        from utils import print_state
+
     log_level = logging.INFO
     logging.basicConfig(level=log_level)
     _LOGGER.setLevel(log_level)
     pygame_connector = PyGameConnector()
     pygame_joystick = WindowsGC102PyGameJoystick(pygame_connector)
-
-    def print_state(state_dict: dict, indent=""):
-        for k, v in state_dict.items():
-            if isinstance(v, dict):
-                print(f"{indent}{k}:")
-                print_state(v, indent + "  ")
-            else:
-                print(f"{indent}{k}: {v}")
 
     while True:
         os.system("cls" if os.name == "nt" else "clear")  # Clear the console

--- a/src/joysticks/logitech_f710_controller.py
+++ b/src/joysticks/logitech_f710_controller.py
@@ -184,19 +184,16 @@ class LogitechF710Joystick:
 if __name__ == "__main__":
     import os
 
+    try:
+        from joysticks.utils import print_state
+    except ModuleNotFoundError:
+        from utils import print_state
+
     log_level = logging.INFO
     logging.basicConfig(level=log_level)
     _LOGGER.setLevel(log_level)
     pygame_connector = PyGameConnector()
     pygame_joystick = LogitechF710Joystick(pygame_connector)
-
-    def print_state(state_dict: dict, indent=""):
-        for k, v in state_dict.items():
-            if isinstance(v, dict):
-                print(f"{indent}{k}:")
-                print_state(v, indent + "  ")
-            else:
-                print(f"{indent}{k}: {v}")
 
     while True:
         os.system("cls" if os.name == "nt" else "clear")  # Clear the console

--- a/src/joysticks/utils.py
+++ b/src/joysticks/utils.py
@@ -1,0 +1,7 @@
+def print_state(state_dict: dict, indent: str = "") -> None:
+    for k, v in state_dict.items():
+        if isinstance(v, dict):
+            print(f"{indent}{k}:")
+            print_state(v, indent + "  ")
+        else:
+            print(f"{indent}{k}: {v}")

--- a/src/joysticks/xbox_controller.py
+++ b/src/joysticks/xbox_controller.py
@@ -65,19 +65,16 @@ class XboxPyGameController(GameController):
 if __name__ == "__main__":
     import os
 
+    try:
+        from joysticks.utils import print_state
+    except ModuleNotFoundError:
+        from utils import print_state
+
     log_level = logging.INFO
     logging.basicConfig(level=log_level)
     _LOGGER.setLevel(log_level)
     pygame_connector = PyGameConnector()
     pygame_joystick = XboxPyGameController(pygame_connector)
-
-    def print_state(state_dict: dict, indent=""):
-        for k, v in state_dict.items():
-            if isinstance(v, dict):
-                print(f"{indent}{k}:")
-                print_state(v, indent + "  ")
-            else:
-                print(f"{indent}{k}: {v}")
 
     while True:
         os.system("cls" if os.name == "nt" else "clear")  # Clear the console

--- a/src/joysticks/xbox_controller_mac.py
+++ b/src/joysticks/xbox_controller_mac.py
@@ -211,19 +211,16 @@ class MacXboxPyGameJoystick(GameController):
 if __name__ == "__main__":
     import os
 
+    try:
+        from joysticks.utils import print_state
+    except ModuleNotFoundError:
+        from utils import print_state
+
     log_level = logging.INFO
     logging.basicConfig(level=log_level)
     _LOGGER.setLevel(log_level)
     pygame_connector = PyGameConnector()
     pygame_joystick = MacXboxPyGameJoystick(pygame_connector)
-
-    def print_state(state_dict: dict, indent=""):
-        for k, v in state_dict.items():
-            if isinstance(v, dict):
-                print(f"{indent}{k}:")
-                print_state(v, indent + "  ")
-            else:
-                print(f"{indent}{k}: {v}")
 
     while True:
         os.system("cls" if os.name == "nt" else "clear")  # Clear the console

--- a/src/joysticks/xbox_controller_windows.py
+++ b/src/joysticks/xbox_controller_windows.py
@@ -207,19 +207,16 @@ class WindowsXboxPyGameJoystick(GameController):
 if __name__ == "__main__":
     import os
 
+    try:
+        from joysticks.utils import print_state
+    except ModuleNotFoundError:
+        from utils import print_state
+
     log_level = logging.INFO
     logging.basicConfig(level=log_level)
     _LOGGER.setLevel(log_level)
     pygame_connector = PyGameConnector()
     pygame_joystick = WindowsXboxPyGameJoystick(pygame_connector)
-
-    def print_state(state_dict: dict, indent=""):
-        for k, v in state_dict.items():
-            if isinstance(v, dict):
-                print(f"{indent}{k}:")
-                print_state(v, indent + "  ")
-            else:
-                print(f"{indent}{k}: {v}")
 
     while True:
         os.system("cls" if os.name == "nt" else "clear")  # Clear the console

--- a/src/joysticks/xbox_one_controller.py
+++ b/src/joysticks/xbox_one_controller.py
@@ -59,13 +59,10 @@ class XboxOnePyGameController(GameController):
 if __name__ == "__main__":
     import os
 
-    def print_state(state_dict, indent=""):
-        for k, v in state_dict.items():
-            if isinstance(v, dict):
-                print(f"{indent}{k}:")
-                print_state(v, indent + "  ")
-            else:
-                print(f"{indent}{k}: {v}")
+    try:
+        from joysticks.utils import print_state
+    except ModuleNotFoundError:
+        from utils import print_state
 
     log_level = logging.DEBUG
     logging.basicConfig(level=log_level)

--- a/src/joysticks/xbox_one_controller_linux.py
+++ b/src/joysticks/xbox_one_controller_linux.py
@@ -205,19 +205,16 @@ class LinuxXboxOnePyGameJoystick(GameController):
 if __name__ == "__main__":
     import os
 
+    try:
+        from joysticks.utils import print_state
+    except ModuleNotFoundError:
+        from utils import print_state
+
     log_level = logging.INFO
     logging.basicConfig(level=log_level)
     LOGGER.setLevel(log_level)
     pygame_connector = PyGameConnector()
     pygame_joystick = LinuxXboxOnePyGameJoystick(pygame_connector)
-
-    def print_state(state_dict: dict, indent=""):
-        for k, v in state_dict.items():
-            if isinstance(v, dict):
-                print(f"{indent}{k}:")
-                print_state(v, indent + "  ")
-            else:
-                print(f"{indent}{k}: {v}")
 
     while True:
         os.system("cls" if os.name == "nt" else "clear")  # Clear the console

--- a/src/joysticks/xbox_one_controller_windows.py
+++ b/src/joysticks/xbox_one_controller_windows.py
@@ -202,19 +202,16 @@ class WindowsXboxOnePyGameJoystick(GameController):
 if __name__ == "__main__":
     import os
 
+    try:
+        from joysticks.utils import print_state
+    except ModuleNotFoundError:
+        from utils import print_state
+
     log_level = logging.INFO
     logging.basicConfig(level=log_level)
     LOGGER.setLevel(log_level)
     pygame_connector = PyGameConnector()
     pygame_joystick = WindowsXboxOnePyGameJoystick(pygame_connector)
-
-    def print_state(state_dict: dict, indent=""):
-        for k, v in state_dict.items():
-            if isinstance(v, dict):
-                print(f"{indent}{k}:")
-                print_state(v, indent + "  ")
-            else:
-                print(f"{indent}{k}: {v}")
 
     while True:
         os.system("cls" if os.name == "nt" else "clear")  # Clear the console


### PR DESCRIPTION
## Summary

Scheduled audit for speed/memory optimizations and redundant functionality. Checked against the repo's history of similar prior cleanups (#8, #11, #15, #17, #18) to avoid re-doing already-fixed work, and found three remaining genuine issues:

- **Duplicated `print_state` debug helper**: the identical ~7-line recursive dict-printer was copy-pasted into the `if __name__ == "__main__":` block of 9 separate joystick modules (`xbox_controller.py`, `xbox_controller_windows.py`, `xbox_controller_mac.py`, `xbox_one_controller.py`, `xbox_one_controller_linux.py`, `xbox_one_controller_windows.py`, `gc102_controller.py`, `gc102_controller_windows.py`, `logitech_f710_controller.py`). Extracted into `src/joysticks/utils.py`, following the same pattern `controller_adapters/utils.py` already uses for `run_adapter_test`.
- **Duplicated face-tracking loop**: `follow_face.py` and `mock_follow_face.py` had ~55 character-for-character identical lines (closest-face selection, box/crosshair drawing, control-state computation, on-frame text overlay). Extracted into `src/face_tracking/tracking_frame_processor.py::process_tracking_frame`; both scripts now just differ in frame source and whether the control state is actually dispatched to the drone.
- **Resource leak in `sanity_check.py`**: the camera-preview loop called `cam.release()` on exit but never `cv2.destroyAllWindows()`, the same leak class already fixed in `follow_face.py`/`mock_follow_face.py` in #17 but missed in this file.

No behavior changes — same control flow and output, just deduplicated.

## Test plan

- [x] `python3 -m py_compile` on all touched/added files — passes
- [ ] Manual smoke test of `follow_face.py` / `mock_follow_face.py` / a joystick module's `__main__` block (needs a connected Tello/camera/controller and `djitellopy`/`pygame`/`opencv-python`, not available in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_014XpXEsAWcwLLiCK7V27dvp)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788938800&installation_model_id=422527&pr_number=19&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F19&signature=9a1f44f26b4465b08a0e7ed89297cc0b7ac4057c313a1c13668e2481b6dbc113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared face-tracking processing with face detection, closest-face selection, tracking overlays, control-state computation, and telemetry display.
  - Improved handling when no face or control state is available.
  - Added reusable controller-state formatting for nested values.

- **Bug Fixes**
  - Ensured camera windows close cleanly after use.
  - Added OpenCV support for face-tracking checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->