### PR TITLE
fix(face_tracking): refresh preview and handle quit/hover on no-face frames

### DIFF
--- a/src/example_exercises/follow_face.py
+++ b/src/example_exercises/follow_face.py
@@ -12,7 +12,19 @@ import logging
 import argparse
 from services.tello_command_dispatcher import TelloCommandDispatcher
 from services.tello_connector import TelloConnector
+from services.tello_controller import TelloControlState
 from controller_adapters.follow_face_controller import FaceFollowingController
+
+
+# Zero-velocity state used to hover in place when no face is tracked, rather
+# than leaving the drone on whatever velocity the last tracked face produced.
+HOVER_STATE = TelloControlState(
+    right_velocity=0,
+    forward_velocity=0,
+    up_velocity=0,
+    yaw_right_velocity=0,
+    events=[],
+)
 
 
 args = argparse.ArgumentParser()
@@ -69,10 +81,10 @@ while True:
     control_state = process_tracking_frame(
         frame, face_identifier, image_drawer, controller, open_cv, DEPTH_TARGET, LOGGER
     )
-    if control_state is None:
-        continue
 
-    dispatcher.send_commands(control_state)
+    # No face tracked this frame: hover in place instead of holding the last
+    # velocity. The preview and quit key are still handled below either way.
+    dispatcher.send_commands(control_state if control_state is not None else HOVER_STATE)
 
     if open_cv.listen_for_key(1) & 0xFF == ord("q"):
         break

--- a/src/example_exercises/mock_follow_face.py
+++ b/src/example_exercises/mock_follow_face.py
@@ -54,11 +54,12 @@ while True:
         LOGGER.debug("No frame")
         continue
 
-    control_state = process_tracking_frame(
+    # process_tracking_frame refreshes the preview (with or without a face);
+    # control_state is None when no face is tracked. The mock does not dispatch
+    # to a drone, so we only need to keep handling the quit key every frame.
+    process_tracking_frame(
         frame, face_identifier, image_drawer, controller, open_cv, DEPTH_TARGET, LOGGER
     )
-    if control_state is None:
-        continue
 
     # dispatcher.send_commands(control_state)
 

--- a/src/face_tracking/tracking_frame_processor.py
+++ b/src/face_tracking/tracking_frame_processor.py
@@ -27,6 +27,18 @@ def process_tracking_frame(
     faces_trbl = face_identifier.identify_faces(frame)
     if not faces_trbl:
         logger.debug("No faces")
+        # Keep the preview alive even with no face in frame so the window
+        # refreshes and the caller's quit-key handling still runs.
+        open_cv.write_text(
+            frame,
+            "No face detected",
+            (10, frame.shape[0] - 10),
+            cv2.FONT_HERSHEY_DUPLEX,
+            0.5,
+            (255, 255, 255),
+            1,
+        )
+        open_cv.show_image("frame", frame)
         return None
 
     frame_center_xyz = (*get_frame_center_xy(frame), depth_target)


### PR DESCRIPTION
Closes #20

## Summary
When no face is detected, `process_tracking_frame` returned early **before** drawing/showing the frame, so the preview window stopped refreshing and the `q` quit key could not be processed while no face was in view. In `follow_face.py`, the drone also kept whatever velocity the last tracked face produced.

- `src/face_tracking/tracking_frame_processor.py` — on the no-face path, write a `"No face detected"` overlay and call `open_cv.show_image` so the preview keeps refreshing (still returns `None`).
- `src/example_exercises/follow_face.py` — dispatch an explicit zero-velocity `HOVER_STATE` when no face is tracked instead of `continue`-ing on the last velocity, and always run the quit-key check each frame.
- `src/example_exercises/mock_follow_face.py` — drop the early `continue` so the quit key is handled every frame (the mock does not dispatch to a drone).

## Test plan
- [ ] Run `mock_follow_face.py` with a webcam; step out of frame and confirm the preview keeps updating (shows "No face detected") and `q` still quits.
- [ ] With a drone (`NO_TAKEOFF`/grounded where possible), confirm that losing the face results in a hover (zero RC velocity) rather than drifting on the last command, and `q` quits while no face is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VfsKkbVXCADvYC9N6kQiKJ)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789269662&installation_model_id=422527&pr_number=21&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F21&signature=3795f135c799a99440efd1f605bee00a0bcabfe571e9d7ee663992e04f462549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Face-following mode now keeps the drone stationary when no face is detected, instead of continuing with its previous movement.
  * Added a visible “No face detected” message to tracking previews.
  * Quit-key handling continues to work even when no face is being tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->