### PR TITLE
chore: dedupe get_pressed_buttons and print_state across controllers

### DIFF
--- a/src/controller_adapters/utils.py
+++ b/src/controller_adapters/utils.py
@@ -2,15 +2,7 @@
 import os
 import time
 from services.tello_controller import TelloController
-
-def print_state(state_dict: dict, indent=""):
-    for k, v in state_dict.items():
-        if isinstance(v, dict):
-            print(f"{indent}{k}:")
-            print_state(v, indent + "  ")
-        else:
-            print(f"{indent}{k}: {v}")
-
+from joysticks.utils import print_state
 
 
 def run_adapter_test(contoller: TelloController) -> None:

--- a/src/joysticks/game_controller.py
+++ b/src/joysticks/game_controller.py
@@ -31,9 +31,8 @@ class ControllerDPadState:
 
 
 class ControllerButtonPressedState(ABC):
-    @abstractmethod
     def get_pressed_buttons(self) -> List[str]:
-        pass
+        return [field.name for field in fields(self) if getattr(self, field.name)]
 
 
 @dataclass

--- a/src/joysticks/gc102_controller_windows.py
+++ b/src/joysticks/gc102_controller_windows.py
@@ -2,8 +2,7 @@
 This module contains the implementation of a General "GC102 Wireless" controller that works with windows systems.
 """
 
-from dataclasses import dataclass, fields
-from typing import List
+from dataclasses import dataclass
 from enum import Enum
 import logging
 import time
@@ -77,9 +76,6 @@ class _ButtonPressedState(ControllerButtonPressedState):
     LEFT_STICK: bool
     RIGHT_STICK: bool
     HOME: bool
-
-    def get_pressed_buttons(self) -> List[str]:
-        return [field.name for field in fields(self) if getattr(self, field.name)]
 
 
 # Button keys that are not assigned to any button on the controller

--- a/src/joysticks/logitech_f710_controller.py
+++ b/src/joysticks/logitech_f710_controller.py
@@ -6,10 +6,9 @@ Confirmed working on Windows and Linux systems.
    
 """
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 import time
 import logging
-from typing import List
 from enum import Enum
 
 try:
@@ -76,9 +75,6 @@ class _ControllerButtonPressedState(ControllerButtonPressedState):
     Start: bool
     LEFT_STICK: bool
     RIGHT_STICK: bool
-
-    def get_pressed_buttons(self) -> List[str]:
-        return [field.name for field in fields(self) if getattr(self, field.name)]
 
 
 class LogitechF710Joystick:

--- a/src/joysticks/tectinter_controller_windows.py
+++ b/src/joysticks/tectinter_controller_windows.py
@@ -4,11 +4,10 @@ https://de.aliexpress.com/item/32824692489.html?spm=a2g0o.order_list.order_list_
 ![Here](../../docs/images/ali_express_controller.jpeg)
 """
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 from enum import Enum
 import time
 import logging
-from typing import List
 
 
 try:
@@ -77,9 +76,6 @@ class _ButtonPressedState(ControllerButtonPressedState):
     HOME: bool
     LEFT_STICK: bool
     RIGHT_STICK: bool
-
-    def get_pressed_buttons(self) -> List[str]:
-        return [field.name for field in fields(self) if getattr(self, field.name)]
 
 
 class TectInterJoystick:

--- a/src/joysticks/xbox_controller_linux.py
+++ b/src/joysticks/xbox_controller_linux.py
@@ -10,8 +10,7 @@ The `Controller` abstract base class defines the interface for getting the curre
 The `XboxPyGameJoystick` class is a concrete implementation of the `Controller` interface using the PyGame library.
 """
 
-from dataclasses import dataclass, fields
-from typing import List
+from dataclasses import dataclass
 from enum import Enum
 import logging
 import time
@@ -85,9 +84,6 @@ class ButtonPressedState(ControllerButtonPressedState):
     NA: bool
     LEFT_STICK: bool
     RIGHT_STICK: bool
-
-    def get_pressed_buttons(self) -> List[str]:
-        return [field.name for field in fields(self) if getattr(self, field.name)]
 
 
 class LinuxXboxPyGameJoystick(GameController):

--- a/src/joysticks/xbox_controller_mac.py
+++ b/src/joysticks/xbox_controller_mac.py
@@ -10,8 +10,7 @@ The `Controller` abstract base class defines the interface for getting the curre
 The `XboxPyGameJoystick` class is a concrete implementation of the `Controller` interface using the PyGame library.
 """
 
-from dataclasses import dataclass, fields
-from typing import List
+from dataclasses import dataclass
 from enum import Enum
 import logging
 import time
@@ -88,9 +87,6 @@ class ButtonPressedState(ControllerButtonPressedState):
     SHARE: bool
     LEFT_STICK: bool
     RIGHT_STICK: bool
-
-    def get_pressed_buttons(self) -> List[str]:
-        return [field.name for field in fields(self) if getattr(self, field.name)]
 
 
 class MacXboxPyGameJoystick(GameController):

--- a/src/joysticks/xbox_controller_windows.py
+++ b/src/joysticks/xbox_controller_windows.py
@@ -10,8 +10,7 @@ The `Controller` abstract base class defines the interface for getting the curre
 The `XboxPyGameJoystick` class is a concrete implementation of the `Controller` interface using the PyGame library.
 """
 
-from dataclasses import dataclass, fields
-from typing import List
+from dataclasses import dataclass
 from enum import Enum
 import logging
 import time
@@ -85,9 +84,6 @@ class _ButtonPressedState(ControllerButtonPressedState):
     SCREENSHOT: bool
     LEFT_STICK: bool
     RIGHT_STICK: bool
-
-    def get_pressed_buttons(self) -> List[str]:
-        return [field.name for field in fields(self) if getattr(self, field.name)]
 
 
 # Button keys that are not assigned to any button on the controller

--- a/src/joysticks/xbox_one_controller_linux.py
+++ b/src/joysticks/xbox_one_controller_linux.py
@@ -10,11 +10,10 @@ It provides classes for handling the controller's axes, buttons, and D-pad state
 The `Controller` abstract base class defines the interface for getting the current controller state.
 """
 
-from dataclasses import dataclass, fields
+from dataclasses import dataclass
 import sys
 import time
 import logging
-from typing import List
 from enum import Enum
 
 
@@ -86,9 +85,6 @@ class _ButtonPressedState(ControllerButtonPressedState):
     NA: bool
     LEFT_STICK: bool
     RIGHT_STICK: bool
-
-    def get_pressed_buttons(self) -> List[str]:
-        return [field.name for field in fields(self) if getattr(self, field.name)]
 
 
 class LinuxXboxOnePyGameJoystick(GameController):

--- a/src/joysticks/xbox_one_controller_windows.py
+++ b/src/joysticks/xbox_one_controller_windows.py
@@ -10,8 +10,7 @@ It provides classes for handling the controller's axes, buttons, and D-pad state
 The `Controller` abstract base class defines the interface for getting the current controller state.
 """
 
-from dataclasses import dataclass, fields
-from typing import List
+from dataclasses import dataclass
 from enum import Enum
 import logging
 import sys
@@ -85,9 +84,6 @@ class ButtonPressedState(ControllerButtonPressedState):
     SCREENSHOT: bool
     LEFT_STICK: bool
     RIGHT_STICK: bool
-
-    def get_pressed_buttons(self) -> List[str]:
-        return [field.name for field in fields(self) if getattr(self, field.name)]
 
 
 class WindowsXboxOnePyGameJoystick(GameController):


### PR DESCRIPTION
## Summary

Routine perf/redundancy audit found two clear cases of copy-pasted logic left over from earlier dedup passes (#19 deduped `print_state` across the `joysticks/*.py` files but missed `controller_adapters/utils.py`):

- `get_pressed_buttons()` was defined identically in 8 `_ButtonPressedState`/`ButtonPressedState` dataclasses (`gc102_controller_windows.py`, `logitech_f710_controller.py`, `tectinter_controller_windows.py`, `xbox_controller_linux.py`, `xbox_controller_mac.py`, `xbox_controller_windows.py`, `xbox_one_controller_linux.py`, `xbox_one_controller_windows.py`), even though every one of them already extends the shared `ControllerButtonPressedState` ABC in `joysticks/game_controller.py`. Moved the single implementation onto the base class and dropped the 8 duplicate overrides (plus the now-unused `fields`/`List` imports each one carried).
- `controller_adapters/utils.py` redefined the exact same `print_state` debug helper that `joysticks/utils.py` already exports (extracted in #19). Removed the duplicate and imported the shared one instead.

Purely mechanical dedup — no behavior change. Verified with a standalone dataclass that `get_pressed_buttons()` still returns the pressed-button names correctly after the move, and `ruff check` passes clean on every touched file.

I checked open PRs/issues first (#20/#21 cover an unrelated preview-refresh bug in `follow_face.py`) to avoid duplicating in-flight work; this doesn't touch any of those files.

## Test plan
- [x] `ruff check` on all touched files — clean
- [x] `python3 -c "import ast; ast.parse(...)"` on all touched files — no syntax errors
- [x] Manual check: a fake dataclass subclassing `ControllerButtonPressedState` correctly returns only its truthy field names via the inherited `get_pressed_buttons()`
- [ ] Not run: no automated test suite exists in this repo, and hardware-dependent deps (`pygame`, `cv2`) aren't installed in this environment, so the joystick/controller scripts themselves weren't exercised live

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DjD4255meJXQS6u3a57LrG)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789543722&installation_model_id=422527&pr_number=22&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F22&signature=5c6ee7d7e1e3269824367990d544506d0c7d4e1b675e05cbf9af897c5657f94e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized how pressed controller buttons are identified across supported platforms.
  * Improved consistency of controller state details shown in diagnostic logging.
* **Refactor**
  * Centralized shared controller-state behavior, reducing platform-specific differences and simplifying maintenance.
  * Removed redundant platform-level implementations without changing the controller APIs available to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->