### PR TITLE
chore: dedupe joystick axis reading, share closest-face logic, fix busy-wait

### DIFF
--- a/src/example_exercises/15_circle_dectector.py
+++ b/src/example_exercises/15_circle_dectector.py
@@ -115,6 +115,7 @@ CENTER_TOLERANCE = 30  # Pixel tolerance for centering (roughly 5% of a typical 
 MAX_FRAME_FAILURES = 30
 
 frame_failures = 0
+last_drone_frame = None
 
 while True:
     # Get camera frame from drone or debug camera
@@ -124,6 +125,13 @@ while True:
             img = None
     else:
         img = tello.get_frame_read().frame
+        if img is last_drone_frame:
+            # BackgroundFrameRead.frame never goes back to None once the
+            # stream dies - it just keeps returning the same array object,
+            # so detect a dead stream by identity instead of by None-ness.
+            img = None
+        else:
+            last_drone_frame = img
 
     if img is None:
         # Bounded retry: a dropped frame or two is normal, but a dead

--- a/src/example_exercises/15_circle_dectector.py
+++ b/src/example_exercises/15_circle_dectector.py
@@ -111,16 +111,30 @@ YAW_SENSITIVITY = 0.01  # Rotation sensitivity
 TARGET_RADIUS_MIN = 1  # Minimum radius to consider for navigation
 CENTER_TOLERANCE = 30  # Pixel tolerance for centering (roughly 5% of a typical 640px-wide frame; `width` isn't known yet at this point)
 
+# Max consecutive frame-read failures before giving up and shutting down.
+MAX_FRAME_FAILURES = 30
+
+frame_failures = 0
+
 while True:
     # Get camera frame from drone or debug camera
     if DEBUG_MODE:
         ret, img = cap.read()
         if not ret or img is None:
-            continue
+            img = None
     else:
         img = tello.get_frame_read().frame
-        if img is None:
-            continue
+
+    if img is None:
+        # Bounded retry: a dropped frame or two is normal, but a dead
+        # stream should exit the loop so the cleanup path runs.
+        frame_failures += 1
+        if frame_failures >= MAX_FRAME_FAILURES:
+            print("Video stream lost - shutting down.")
+            break
+        time.sleep(1 / 15)
+        continue
+    frame_failures = 0
 
     # Get frame dimensions
     height, width = img.shape[:2]

--- a/src/face_tracking/sanity_check.py
+++ b/src/face_tracking/sanity_check.py
@@ -15,12 +15,12 @@ from open_cv_wrapper import OpenCvWrapper
 import cv2
 import logging
 import argparse
-from utils.positioning_utils import (
-    get_box_center_xyz,
-    get_distance_xyz,
-    get_frame_center_xy,
-    get_vector_xyz,
-)
+from utils.positioning_utils import get_vector_xyz
+
+try:
+    from tracking_frame_processor import locate_and_draw_closest_face
+except ModuleNotFoundError:
+    from face_tracking.tracking_frame_processor import locate_and_draw_closest_face
 
 
 args = argparse.ArgumentParser()
@@ -57,31 +57,17 @@ while True:
         LOGGER.debug("No faces")
         continue
 
-    frame_center_xyz = (*get_frame_center_xy(frame), DEPTH_TARGET)
-
-    closest = None
-    for face_trbl in faces_trbl:
-        box_center = get_box_center_xyz(face_trbl, DEPTH_TARGET)
-        distance = get_distance_xyz(frame_center_xyz, box_center)
-        if closest is None or distance < closest[1]:
-            closest = (face_trbl, distance, box_center)
-        frame = image_drawer.draw_box(
-            frame,
-            face_trbl,
-            "green",
-            f"{box_center}",
-        )
-        frame = image_drawer.draw_cross_hair_in_box(frame, face_trbl, 4, "green")
-
-    assert closest is not None
-    closest_box = closest[0]
-    closest_distance = closest[1]
-    closest_center = closest[2]
+    (
+        frame,
+        closest_box,
+        closest_distance,
+        closest_center,
+        frame_center_xyz,
+    ) = locate_and_draw_closest_face(
+        frame, faces_trbl, image_drawer, DEPTH_TARGET, label_each_face=True
+    )
 
     vector_to_center = get_vector_xyz(frame_center_xyz, closest_center)
-
-    frame = image_drawer.draw_box(frame, closest_box, "red")
-    frame = image_drawer.draw_frame_center_cross_hair(frame, 2, 20, "red")
 
     LOGGER.debug(
         f"Closest face at {frame_center_xyz, closest_center} with distance {closest_distance}"

--- a/src/face_tracking/tracking_frame_processor.py
+++ b/src/face_tracking/tracking_frame_processor.py
@@ -82,7 +82,7 @@ def process_tracking_frame(
 
     (
         frame,
-        closest_box,
+        _closest_box,
         closest_distance,
         closest_center,
         frame_center_xyz,

--- a/src/face_tracking/tracking_frame_processor.py
+++ b/src/face_tracking/tracking_frame_processor.py
@@ -22,6 +22,7 @@ def locate_and_draw_closest_face(
     """Draws every candidate face and picks the one closest to frame center.
 
     Returns `(frame, closest_box, closest_distance, closest_center, frame_center_xyz)`.
+    `faces_trbl` must be non-empty.
     """
     frame_center_xyz = (*get_frame_center_xy(frame), depth_target)
 
@@ -39,6 +40,9 @@ def locate_and_draw_closest_face(
         )
         frame = image_drawer.draw_cross_hair_in_box(frame, face_trbl, 4, "green")
 
+    assert (
+        closest is not None
+    ), "locate_and_draw_closest_face() requires at least one face"
     closest_box, closest_distance, closest_center = closest
 
     frame = image_drawer.draw_box(frame, closest_box, "red")

--- a/src/face_tracking/tracking_frame_processor.py
+++ b/src/face_tracking/tracking_frame_processor.py
@@ -12,6 +12,41 @@ from face_tracking.utils.positioning_utils import (
 )
 
 
+def locate_and_draw_closest_face(
+    frame,
+    faces_trbl,
+    image_drawer,
+    depth_target: int,
+    label_each_face: bool = False,
+):
+    """Draws every candidate face and picks the one closest to frame center.
+
+    Returns `(frame, closest_box, closest_distance, closest_center, frame_center_xyz)`.
+    """
+    frame_center_xyz = (*get_frame_center_xy(frame), depth_target)
+
+    closest = None
+    for face_trbl in faces_trbl:
+        box_center = get_box_center_xyz(face_trbl, depth_target)
+        distance = get_distance_xyz(frame_center_xyz, box_center)
+        if closest is None or distance < closest[1]:
+            closest = (face_trbl, distance, box_center)
+        frame = image_drawer.draw_box(
+            frame,
+            face_trbl,
+            "green",
+            f"{box_center}" if label_each_face else "",
+        )
+        frame = image_drawer.draw_cross_hair_in_box(frame, face_trbl, 4, "green")
+
+    closest_box, closest_distance, closest_center = closest
+
+    frame = image_drawer.draw_box(frame, closest_box, "red")
+    frame = image_drawer.draw_frame_center_cross_hair(frame, 2, 20, "red")
+
+    return frame, closest_box, closest_distance, closest_center, frame_center_xyz
+
+
 def process_tracking_frame(
     frame,
     face_identifier,
@@ -41,27 +76,15 @@ def process_tracking_frame(
         open_cv.show_image("frame", frame)
         return None
 
-    frame_center_xyz = (*get_frame_center_xy(frame), depth_target)
-
-    closest = None
-    for face_trbl in faces_trbl:
-        box_center = get_box_center_xyz(face_trbl, depth_target)
-        distance = get_distance_xyz(frame_center_xyz, box_center)
-        if closest is None or distance < closest[1]:
-            closest = (face_trbl, distance, box_center)
-        frame = image_drawer.draw_box(
-            frame,
-            face_trbl,
-            "green",
-        )
-        frame = image_drawer.draw_cross_hair_in_box(frame, face_trbl, 4, "green")
-
-    closest_box, closest_distance, closest_center = closest
+    (
+        frame,
+        closest_box,
+        closest_distance,
+        closest_center,
+        frame_center_xyz,
+    ) = locate_and_draw_closest_face(frame, faces_trbl, image_drawer, depth_target)
 
     vector_to_center = get_vector_xyz(frame_center_xyz, closest_center)
-
-    frame = image_drawer.draw_box(frame, closest_box, "red")
-    frame = image_drawer.draw_frame_center_cross_hair(frame, 2, 20, "red")
 
     logger.debug(
         "Closest face at %s with distance %s",

--- a/src/joysticks/game_controller.py
+++ b/src/joysticks/game_controller.py
@@ -92,3 +92,18 @@ class GameController(ABC):
 def apply_dead_zone(value: float, dead_zone: float) -> float:
     """Zeroes out axis noise/drift smaller than the dead zone threshold."""
     return 0.0 if abs(value) < dead_zone else value
+
+
+def read_stick_state(
+    joystick, horizontal_axis: int, vertical_axis: int, dead_zone: float
+) -> StickState:
+    """Reads one analog stick's two axes and applies the dead zone to each."""
+    return StickState(
+        horizontal_right=apply_dead_zone(joystick.get_axis(horizontal_axis), dead_zone),
+        vertical_down=apply_dead_zone(joystick.get_axis(vertical_axis), dead_zone),
+    )
+
+
+def read_axis(joystick, axis: int, dead_zone: float) -> float:
+    """Reads a single axis (e.g. an analog trigger) and applies the dead zone."""
+    return apply_dead_zone(joystick.get_axis(axis), dead_zone)

--- a/src/joysticks/gc102_controller_windows.py
+++ b/src/joysticks/gc102_controller_windows.py
@@ -2,34 +2,34 @@
 This module contains the implementation of a General "GC102 Wireless" controller that works with windows systems.
 """
 
+import logging
+import sys
+import time
 from dataclasses import dataclass
 from enum import Enum
-import logging
-import time
-import sys
 
 try:
-    from joysticks.pygame_connector import PyGameConnector
     from joysticks.game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from joysticks.pygame_connector import PyGameConnector
 except ModuleNotFoundError:
-    from pygame_connector import PyGameConnector
     from game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from pygame_connector import PyGameConnector
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -124,43 +124,25 @@ class WindowsGC102PyGameJoystick(GameController):
     def get_state(self) -> GameControllerState:
         self.pygame_connector.get_events()
 
-        left_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_HORIZONTAL.value
-        )
-        left_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_VERTICAL.value
-        )
-        right_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_HORIZONTAL.value
-        )
-        right_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_VERTICAL.value
-        )
-        left_analog_trigger = self.joystick.get_axis(
-            _AxisKeys.LEFT_ANALOG_TRIGGER.value
-        )
-        right_analog_trigger = self.joystick.get_axis(
-            _AxisKeys.RIGHT_ANALOG_TRIGGER.value
-        )
-
-        left_stick_horizontal = apply_dead_zone(left_stick_horizontal, self.dead_zone)
-        left_stick_vertical = apply_dead_zone(left_stick_vertical, self.dead_zone)
-        right_stick_horizontal = apply_dead_zone(right_stick_horizontal, self.dead_zone)
-        right_stick_vertical = apply_dead_zone(right_stick_vertical, self.dead_zone)
-        left_analog_trigger = apply_dead_zone(left_analog_trigger, self.dead_zone)
-        right_analog_trigger = apply_dead_zone(right_analog_trigger, self.dead_zone)
-
         axes = ControllerAxesState(
-            left_stick=StickState(
-                horizontal_right=left_stick_horizontal,
-                vertical_down=left_stick_vertical,
+            left_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.LEFT_STICK_HORIZONTAL.value,
+                _AxisKeys.LEFT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            right_stick=StickState(
-                horizontal_right=right_stick_horizontal,
-                vertical_down=right_stick_vertical,
+            right_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.RIGHT_STICK_HORIZONTAL.value,
+                _AxisKeys.RIGHT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            left_analog_trigger=left_analog_trigger,
-            right_analog_trigger=right_analog_trigger,
+            left_analog_trigger=read_axis(
+                self.joystick, _AxisKeys.LEFT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
+            right_analog_trigger=read_axis(
+                self.joystick, _AxisKeys.RIGHT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
         )
 
         buttons = _ButtonPressedState(

--- a/src/joysticks/logitech_f710_controller.py
+++ b/src/joysticks/logitech_f710_controller.py
@@ -6,31 +6,29 @@ Confirmed working on Windows and Linux systems.
    
 """
 
-from dataclasses import dataclass
-import time
 import logging
+import time
+from dataclasses import dataclass
 from enum import Enum
 
 try:
-    from joysticks.pygame_connector import PyGameConnector
     from joysticks.game_controller import (
         ControllerAxesState,
-        StickState,
-        GameControllerState,
         ControllerButtonPressedState,
         ControllerDPadState,
-        apply_dead_zone,
+        GameControllerState,
+        read_stick_state,
     )
+    from joysticks.pygame_connector import PyGameConnector
 except ModuleNotFoundError:
-    from pygame_connector import PyGameConnector
     from game_controller import (
         ControllerAxesState,
-        StickState,
-        GameControllerState,
         ControllerButtonPressedState,
         ControllerDPadState,
-        apply_dead_zone,
+        GameControllerState,
+        read_stick_state,
     )
+    from pygame_connector import PyGameConnector
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -114,32 +112,18 @@ class LogitechF710Joystick:
     def get_state(self) -> GameControllerState:
         self.pygame_connector.get_events()
 
-        left_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_HORIZONTAL.value
-        )
-        left_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_VERTICAL.value
-        )
-        right_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_HORIZONTAL.value
-        )
-        right_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_VERTICAL.value
-        )
-
-        left_stick_horizontal = apply_dead_zone(left_stick_horizontal, self.dead_zone)
-        left_stick_vertical = apply_dead_zone(left_stick_vertical, self.dead_zone)
-        right_stick_horizontal = apply_dead_zone(right_stick_horizontal, self.dead_zone)
-        right_stick_vertical = apply_dead_zone(right_stick_vertical, self.dead_zone)
-
         axes = ControllerAxesState(
-            left_stick=StickState(
-                horizontal_right=left_stick_horizontal,
-                vertical_down=left_stick_vertical,
+            left_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.LEFT_STICK_HORIZONTAL.value,
+                _AxisKeys.LEFT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            right_stick=StickState(
-                horizontal_right=right_stick_horizontal,
-                vertical_down=right_stick_vertical,
+            right_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.RIGHT_STICK_HORIZONTAL.value,
+                _AxisKeys.RIGHT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
             left_analog_trigger=float(
                 self.joystick.get_button(_ButtonKeys.LeftTrigger.value)

--- a/src/joysticks/tectinter_controller_windows.py
+++ b/src/joysticks/tectinter_controller_windows.py
@@ -4,32 +4,31 @@ https://de.aliexpress.com/item/32824692489.html?spm=a2g0o.order_list.order_list_
 ![Here](../../docs/images/ali_express_controller.jpeg)
 """
 
+import logging
+import time
 from dataclasses import dataclass
 from enum import Enum
-import time
-import logging
-
 
 try:
-    from joysticks.pygame_connector import PyGameConnector
     from joysticks.game_controller import (
         ControllerAxesState,
+        ControllerButtonPressedState,
         ControllerDPadState,
         GameControllerState,
-        StickState,
-        ControllerButtonPressedState,
-        apply_dead_zone,
+        read_axis,
+        read_stick_state,
     )
+    from joysticks.pygame_connector import PyGameConnector
 except ModuleNotFoundError:
-    from pygame_connector import PyGameConnector
     from game_controller import (
         ControllerAxesState,
+        ControllerButtonPressedState,
         ControllerDPadState,
         GameControllerState,
-        StickState,
-        ControllerButtonPressedState,
-        apply_dead_zone,
+        read_axis,
+        read_stick_state,
     )
+    from pygame_connector import PyGameConnector
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -116,39 +115,25 @@ class TectInterJoystick:
     def get_state(self) -> GameControllerState:
         self.pygame_connector.get_events()
 
-        left_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_HORIZONTAL.value
-        )
-        left_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_VERTICAL.value
-        )
-        right_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_HORIZONTAL.value
-        )
-        right_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_VERTICAL.value
-        )
-        left_analog_trigger = self.joystick.get_axis(_AxisKeys.LEFT_TRIGGER.value)
-        right_analog_trigger = self.joystick.get_axis(_AxisKeys.RIGHT_TRIGGER.value)
-
-        left_stick_horizontal = apply_dead_zone(left_stick_horizontal, self.dead_zone)
-        left_stick_vertical = apply_dead_zone(left_stick_vertical, self.dead_zone)
-        right_stick_horizontal = apply_dead_zone(right_stick_horizontal, self.dead_zone)
-        right_stick_vertical = apply_dead_zone(right_stick_vertical, self.dead_zone)
-        left_analog_trigger = apply_dead_zone(left_analog_trigger, self.dead_zone)
-        right_analog_trigger = apply_dead_zone(right_analog_trigger, self.dead_zone)
-
         axes = ControllerAxesState(
-            left_stick=StickState(
-                horizontal_right=left_stick_horizontal,
-                vertical_down=left_stick_vertical,
+            left_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.LEFT_STICK_HORIZONTAL.value,
+                _AxisKeys.LEFT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            right_stick=StickState(
-                horizontal_right=right_stick_horizontal,
-                vertical_down=right_stick_vertical,
+            right_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.RIGHT_STICK_HORIZONTAL.value,
+                _AxisKeys.RIGHT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            left_analog_trigger=left_analog_trigger,
-            right_analog_trigger=right_analog_trigger,
+            left_analog_trigger=read_axis(
+                self.joystick, _AxisKeys.LEFT_TRIGGER.value, self.dead_zone
+            ),
+            right_analog_trigger=read_axis(
+                self.joystick, _AxisKeys.RIGHT_TRIGGER.value, self.dead_zone
+            ),
         )
 
         buttons = _ButtonPressedState(

--- a/src/joysticks/xbox_controller_linux.py
+++ b/src/joysticks/xbox_controller_linux.py
@@ -10,34 +10,34 @@ The `Controller` abstract base class defines the interface for getting the curre
 The `XboxPyGameJoystick` class is a concrete implementation of the `Controller` interface using the PyGame library.
 """
 
+import logging
+import sys
+import time
 from dataclasses import dataclass
 from enum import Enum
-import logging
-import time
-import sys
 
 try:
-    from joysticks.pygame_connector import PyGameConnector
     from joysticks.game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from joysticks.pygame_connector import PyGameConnector
 except ModuleNotFoundError:
-    from pygame_connector import PyGameConnector
     from game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from pygame_connector import PyGameConnector
 
 
 LOGGER = logging.getLogger(__name__)
@@ -125,39 +125,25 @@ class LinuxXboxPyGameJoystick(GameController):
     def get_state(self) -> GameControllerState:
         self.pygame_connector.get_events()
 
-        left_stick_horizontal = self.joystick.get_axis(
-            AxisKeys.LEFT_STICK_HORIZONTAL.value
-        )
-        left_stick_vertical = self.joystick.get_axis(AxisKeys.LEFT_STICK_VERTICAL.value)
-        right_stick_horizontal = self.joystick.get_axis(
-            AxisKeys.RIGHT_STICK_HORIZONTAL.value
-        )
-        right_stick_vertical = self.joystick.get_axis(
-            AxisKeys.RIGHT_STICK_VERTICAL.value
-        )
-        left_analog_trigger = self.joystick.get_axis(AxisKeys.LEFT_ANALOG_TRIGGER.value)
-        right_analog_trigger = self.joystick.get_axis(
-            AxisKeys.RIGHT_ANALOG_TRIGGER.value
-        )
-
-        left_stick_horizontal = apply_dead_zone(left_stick_horizontal, self.dead_zone)
-        left_stick_vertical = apply_dead_zone(left_stick_vertical, self.dead_zone)
-        right_stick_horizontal = apply_dead_zone(right_stick_horizontal, self.dead_zone)
-        right_stick_vertical = apply_dead_zone(right_stick_vertical, self.dead_zone)
-        left_analog_trigger = apply_dead_zone(left_analog_trigger, self.dead_zone)
-        right_analog_trigger = apply_dead_zone(right_analog_trigger, self.dead_zone)
-
         axes = ControllerAxesState(
-            left_stick=StickState(
-                horizontal_right=left_stick_horizontal,
-                vertical_down=left_stick_vertical,
+            left_stick=read_stick_state(
+                self.joystick,
+                AxisKeys.LEFT_STICK_HORIZONTAL.value,
+                AxisKeys.LEFT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            right_stick=StickState(
-                horizontal_right=right_stick_horizontal,
-                vertical_down=right_stick_vertical,
+            right_stick=read_stick_state(
+                self.joystick,
+                AxisKeys.RIGHT_STICK_HORIZONTAL.value,
+                AxisKeys.RIGHT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            left_analog_trigger=left_analog_trigger,
-            right_analog_trigger=right_analog_trigger,
+            left_analog_trigger=read_axis(
+                self.joystick, AxisKeys.LEFT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
+            right_analog_trigger=read_axis(
+                self.joystick, AxisKeys.RIGHT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
         )
 
         buttons = ButtonPressedState(

--- a/src/joysticks/xbox_controller_mac.py
+++ b/src/joysticks/xbox_controller_mac.py
@@ -10,34 +10,34 @@ The `Controller` abstract base class defines the interface for getting the curre
 The `XboxPyGameJoystick` class is a concrete implementation of the `Controller` interface using the PyGame library.
 """
 
+import logging
+import sys
+import time
 from dataclasses import dataclass
 from enum import Enum
-import logging
-import time
-import sys
 
 try:
-    from joysticks.pygame_connector import PyGameConnector
     from joysticks.game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from joysticks.pygame_connector import PyGameConnector
 except ModuleNotFoundError:
-    from pygame_connector import PyGameConnector
     from game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from pygame_connector import PyGameConnector
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -133,43 +133,25 @@ class MacXboxPyGameJoystick(GameController):
     def get_state(self) -> GameControllerState:
         self.pygame_connector.get_events()
 
-        left_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_HORIZONTAL.value
-        )
-        left_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_VERTICAL.value
-        )
-        right_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_HORIZONTAL.value
-        )
-        right_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_VERTICAL.value
-        )
-        left_analog_trigger = self.joystick.get_axis(
-            _AxisKeys.LEFT_ANALOG_TRIGGER.value
-        )
-        right_analog_trigger = self.joystick.get_axis(
-            _AxisKeys.RIGHT_ANALOG_TRIGGER.value
-        )
-
-        left_stick_horizontal = apply_dead_zone(left_stick_horizontal, self.dead_zone)
-        left_stick_vertical = apply_dead_zone(left_stick_vertical, self.dead_zone)
-        right_stick_horizontal = apply_dead_zone(right_stick_horizontal, self.dead_zone)
-        right_stick_vertical = apply_dead_zone(right_stick_vertical, self.dead_zone)
-        left_analog_trigger = apply_dead_zone(left_analog_trigger, self.dead_zone)
-        right_analog_trigger = apply_dead_zone(right_analog_trigger, self.dead_zone)
-
         axes = ControllerAxesState(
-            left_stick=StickState(
-                horizontal_right=left_stick_horizontal,
-                vertical_down=left_stick_vertical,
+            left_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.LEFT_STICK_HORIZONTAL.value,
+                _AxisKeys.LEFT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            right_stick=StickState(
-                horizontal_right=right_stick_horizontal,
-                vertical_down=right_stick_vertical,
+            right_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.RIGHT_STICK_HORIZONTAL.value,
+                _AxisKeys.RIGHT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            left_analog_trigger=left_analog_trigger,
-            right_analog_trigger=right_analog_trigger,
+            left_analog_trigger=read_axis(
+                self.joystick, _AxisKeys.LEFT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
+            right_analog_trigger=read_axis(
+                self.joystick, _AxisKeys.RIGHT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
         )
 
         buttons = ButtonPressedState(

--- a/src/joysticks/xbox_controller_windows.py
+++ b/src/joysticks/xbox_controller_windows.py
@@ -10,34 +10,34 @@ The `Controller` abstract base class defines the interface for getting the curre
 The `XboxPyGameJoystick` class is a concrete implementation of the `Controller` interface using the PyGame library.
 """
 
+import logging
+import sys
+import time
 from dataclasses import dataclass
 from enum import Enum
-import logging
-import time
-import sys
 
 try:
-    from joysticks.pygame_connector import PyGameConnector
     from joysticks.game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from joysticks.pygame_connector import PyGameConnector
 except ModuleNotFoundError:
-    from pygame_connector import PyGameConnector
     from game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from pygame_connector import PyGameConnector
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -132,43 +132,25 @@ class WindowsXboxPyGameJoystick(GameController):
     def get_state(self) -> GameControllerState:
         self.pygame_connector.get_events()
 
-        left_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_HORIZONTAL.value
-        )
-        left_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_VERTICAL.value
-        )
-        right_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_HORIZONTAL.value
-        )
-        right_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_VERTICAL.value
-        )
-        left_analog_trigger = self.joystick.get_axis(
-            _AxisKeys.LEFT_ANALOG_TRIGGER.value
-        )
-        right_analog_trigger = self.joystick.get_axis(
-            _AxisKeys.RIGHT_ANALOG_TRIGGER.value
-        )
-
-        left_stick_horizontal = apply_dead_zone(left_stick_horizontal, self.dead_zone)
-        left_stick_vertical = apply_dead_zone(left_stick_vertical, self.dead_zone)
-        right_stick_horizontal = apply_dead_zone(right_stick_horizontal, self.dead_zone)
-        right_stick_vertical = apply_dead_zone(right_stick_vertical, self.dead_zone)
-        left_analog_trigger = apply_dead_zone(left_analog_trigger, self.dead_zone)
-        right_analog_trigger = apply_dead_zone(right_analog_trigger, self.dead_zone)
-
         axes = ControllerAxesState(
-            left_stick=StickState(
-                horizontal_right=left_stick_horizontal,
-                vertical_down=left_stick_vertical,
+            left_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.LEFT_STICK_HORIZONTAL.value,
+                _AxisKeys.LEFT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            right_stick=StickState(
-                horizontal_right=right_stick_horizontal,
-                vertical_down=right_stick_vertical,
+            right_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.RIGHT_STICK_HORIZONTAL.value,
+                _AxisKeys.RIGHT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            left_analog_trigger=left_analog_trigger,
-            right_analog_trigger=right_analog_trigger,
+            left_analog_trigger=read_axis(
+                self.joystick, _AxisKeys.LEFT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
+            right_analog_trigger=read_axis(
+                self.joystick, _AxisKeys.RIGHT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
         )
 
         buttons = _ButtonPressedState(

--- a/src/joysticks/xbox_one_controller_linux.py
+++ b/src/joysticks/xbox_one_controller_linux.py
@@ -10,35 +10,34 @@ It provides classes for handling the controller's axes, buttons, and D-pad state
 The `Controller` abstract base class defines the interface for getting the current controller state.
 """
 
-from dataclasses import dataclass
+import logging
 import sys
 import time
-import logging
+from dataclasses import dataclass
 from enum import Enum
 
-
 try:
-    from joysticks.pygame_connector import PyGameConnector
     from joysticks.game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from joysticks.pygame_connector import PyGameConnector
 except ModuleNotFoundError:
-    from pygame_connector import PyGameConnector
     from game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from pygame_connector import PyGameConnector
 
 
 LOGGER = logging.getLogger(__name__)
@@ -96,7 +95,6 @@ class LinuxXboxOnePyGameJoystick(GameController):
     """
 
     def __init__(self, pygame_connector: PyGameConnector, joystick_id: int = 0):
-
         if "linux" not in sys.platform.lower():
             raise ValueError(f"Linux adapter is being used on a {sys.platform} system")
 
@@ -130,43 +128,25 @@ class LinuxXboxOnePyGameJoystick(GameController):
     def get_state(self) -> GameControllerState:
         self.pygame_connector.get_events()
 
-        left_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_HORIZONTAL.value
-        )
-        left_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.LEFT_STICK_VERTICAL.value
-        )
-        right_stick_horizontal = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_HORIZONTAL.value
-        )
-        right_stick_vertical = self.joystick.get_axis(
-            _AxisKeys.RIGHT_STICK_VERTICAL.value
-        )
-        left_analog_trigger = self.joystick.get_axis(
-            _AxisKeys.LEFT_ANALOG_TRIGGER.value
-        )
-        right_analog_trigger = self.joystick.get_axis(
-            _AxisKeys.RIGHT_ANALOG_TRIGGER.value
-        )
-
-        left_stick_horizontal = apply_dead_zone(left_stick_horizontal, self.dead_zone)
-        left_stick_vertical = apply_dead_zone(left_stick_vertical, self.dead_zone)
-        right_stick_horizontal = apply_dead_zone(right_stick_horizontal, self.dead_zone)
-        right_stick_vertical = apply_dead_zone(right_stick_vertical, self.dead_zone)
-        left_analog_trigger = apply_dead_zone(left_analog_trigger, self.dead_zone)
-        right_analog_trigger = apply_dead_zone(right_analog_trigger, self.dead_zone)
-
         axes = ControllerAxesState(
-            left_stick=StickState(
-                horizontal_right=left_stick_horizontal,
-                vertical_down=left_stick_vertical,
+            left_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.LEFT_STICK_HORIZONTAL.value,
+                _AxisKeys.LEFT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            right_stick=StickState(
-                horizontal_right=right_stick_horizontal,
-                vertical_down=right_stick_vertical,
+            right_stick=read_stick_state(
+                self.joystick,
+                _AxisKeys.RIGHT_STICK_HORIZONTAL.value,
+                _AxisKeys.RIGHT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            left_analog_trigger=left_analog_trigger,
-            right_analog_trigger=right_analog_trigger,
+            left_analog_trigger=read_axis(
+                self.joystick, _AxisKeys.LEFT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
+            right_analog_trigger=read_axis(
+                self.joystick, _AxisKeys.RIGHT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
         )
 
         buttons = _ButtonPressedState(

--- a/src/joysticks/xbox_one_controller_windows.py
+++ b/src/joysticks/xbox_one_controller_windows.py
@@ -10,35 +10,34 @@ It provides classes for handling the controller's axes, buttons, and D-pad state
 The `Controller` abstract base class defines the interface for getting the current controller state.
 """
 
-from dataclasses import dataclass
-from enum import Enum
 import logging
 import sys
 import time
-
+from dataclasses import dataclass
+from enum import Enum
 
 try:
-    from joysticks.pygame_connector import PyGameConnector
     from joysticks.game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from joysticks.pygame_connector import PyGameConnector
 except ModuleNotFoundError:
-    from pygame_connector import PyGameConnector
     from game_controller import (
-        GameController,
         ControllerAxesState,
-        ControllerDPadState,
-        GameControllerState,
-        StickState,
         ControllerButtonPressedState,
-        apply_dead_zone,
+        ControllerDPadState,
+        GameController,
+        GameControllerState,
+        read_axis,
+        read_stick_state,
     )
+    from pygame_connector import PyGameConnector
 
 LOGGER = logging.getLogger(__name__)
 
@@ -95,7 +94,6 @@ class WindowsXboxOnePyGameJoystick(GameController):
     """
 
     def __init__(self, pygame_connector: PyGameConnector, joystick_id: int = 0):
-
         if "win" not in sys.platform.lower():
             raise ValueError(
                 f"Windows adapter is being used on a {sys.platform} system"
@@ -131,39 +129,25 @@ class WindowsXboxOnePyGameJoystick(GameController):
     def get_state(self) -> GameControllerState:
         self.pygame_connector.get_events()
 
-        left_stick_horizontal = self.joystick.get_axis(
-            AxisKeys.LEFT_STICK_HORIZONTAL.value
-        )
-        left_stick_vertical = self.joystick.get_axis(AxisKeys.LEFT_STICK_VERTICAL.value)
-        right_stick_horizontal = self.joystick.get_axis(
-            AxisKeys.RIGHT_STICK_HORIZONTAL.value
-        )
-        right_stick_vertical = self.joystick.get_axis(
-            AxisKeys.RIGHT_STICK_VERTICAL.value
-        )
-        left_analog_trigger = self.joystick.get_axis(AxisKeys.LEFT_ANALOG_TRIGGER.value)
-        right_analog_trigger = self.joystick.get_axis(
-            AxisKeys.RIGHT_ANALOG_TRIGGER.value
-        )
-
-        left_stick_horizontal = apply_dead_zone(left_stick_horizontal, self.dead_zone)
-        left_stick_vertical = apply_dead_zone(left_stick_vertical, self.dead_zone)
-        right_stick_horizontal = apply_dead_zone(right_stick_horizontal, self.dead_zone)
-        right_stick_vertical = apply_dead_zone(right_stick_vertical, self.dead_zone)
-        left_analog_trigger = apply_dead_zone(left_analog_trigger, self.dead_zone)
-        right_analog_trigger = apply_dead_zone(right_analog_trigger, self.dead_zone)
-
         axes = ControllerAxesState(
-            left_stick=StickState(
-                horizontal_right=left_stick_horizontal,
-                vertical_down=left_stick_vertical,
+            left_stick=read_stick_state(
+                self.joystick,
+                AxisKeys.LEFT_STICK_HORIZONTAL.value,
+                AxisKeys.LEFT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            right_stick=StickState(
-                horizontal_right=right_stick_horizontal,
-                vertical_down=right_stick_vertical,
+            right_stick=read_stick_state(
+                self.joystick,
+                AxisKeys.RIGHT_STICK_HORIZONTAL.value,
+                AxisKeys.RIGHT_STICK_VERTICAL.value,
+                self.dead_zone,
             ),
-            left_analog_trigger=left_analog_trigger,
-            right_analog_trigger=right_analog_trigger,
+            left_analog_trigger=read_axis(
+                self.joystick, AxisKeys.LEFT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
+            right_analog_trigger=read_axis(
+                self.joystick, AxisKeys.RIGHT_ANALOG_TRIGGER.value, self.dead_zone
+            ),
         )
 
         buttons = ButtonPressedState(


### PR DESCRIPTION
## Summary

Follow-up perf/redundancy pass on top of the earlier cleanup PRs (#15, #17, #19, #21, #22), targeting duplication and a busy-wait those left behind:

- **Joystick axis-read duplication.** Every controller adapter (`xbox_controller_linux/mac/windows.py`, `xbox_one_controller_linux/windows.py`, `gc102_controller_windows.py`, `logitech_f710_controller.py`, `tectinter_controller_windows.py`) re-implemented the same ~30-40 line block in `get_state()`: read each stick/trigger axis, then apply the dead zone to each. #22 only deduped `get_pressed_buttons()`/`print_state()` and left this block untouched. Added `read_stick_state()` and `read_axis()` helpers to `game_controller.py` and wired all 8 adapters through them.
- **Duplicated closest-face tracking loop.** `face_tracking/sanity_check.py` re-implemented the "find faces, pick the closest to center, draw boxes" loop that `tracking_frame_processor.process_tracking_frame()` (used by `follow_face.py`/`mock_follow_face.py`) already provides. Since `sanity_check.py` has no drone controller (it's a controller-free visual sanity check), I extracted just that shared piece into a new `locate_and_draw_closest_face()` helper that both `process_tracking_frame()` and `sanity_check.py` now call, rather than forcing `sanity_check.py` to depend on a controller it doesn't have.
- **CPU busy-wait in `15_circle_dectector.py`.** On a missing/failed camera frame, the loop `continue`d straight back to the top with no throttling and no bound — unlike `16_color_contour_detector.py`, which already handles the identical situation with a `time.sleep(1/15)` backoff and a bounded `MAX_FRAME_FAILURES` retry before giving up. Backported that pattern to file 15.

## Test plan

No test suite exists in this repo (no `pytest` files under `src/`). Instead, verified with `pygame`/mock-based smoke scripts run locally:
- [x] All 8 joystick adapters instantiate and `get_state()` returns axis values equal to the pre-refactor computation (dead zone applied correctly per axis) for every controller.
- [x] `process_tracking_frame()` (used by `follow_face.py`/`mock_follow_face.py`) returns identical control state for both the with-face and no-face cases after the refactor.
- [x] `locate_and_draw_closest_face()` used standalone (as `sanity_check.py` now does) returns the correct closest face and draws per-face labels when requested.
- [x] `black`, `isort`, and `flake8 --select=F401,F821,F841` pass on all changed files with no unused imports or undefined names.
- [x] All changed files parse cleanly (`ast.parse`).

No drone or physical webcam was available to manually run `15_circle_dectector.py`/`sanity_check.py` end-to-end in this environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01966eLiK9zA9RrisYAu3JQj)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790148580&installation_model_id=422527&pr_number=24&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F24&signature=9bd049b6b93d0855ce8fe138267c84bf1c2cb9c91ccb32e438971fd95769d213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Camera processing now retries missing or invalid frames at a controlled rate and exits safely after repeated failures, allowing cleanup to complete.
  * Face tracking now consistently identifies the closest face and displays tracking markers and optional labels.

* **Improvements**
  * Game controller input handling is more consistent across supported platforms, with centralized analog stick and trigger dead-zone filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->