### PR TITLE
ci: route CI jobs to org self-hosted Pi 4 runners

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,8 @@ jobs:
   # skip. Job-level `if:` conditions can't reference `secrets.*` directly, so we
   # check the secret here, emit an output, and gate `claude-review` on it.
   secrets-gate:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, ARM64, rpi]
+    timeout-minutes: 5
     permissions: {}
     outputs:
       ok: ${{ steps.check.outputs.ok }}
@@ -35,7 +36,7 @@ jobs:
   claude-review:
     needs: secrets-gate
     if: ${{ needs.secrets-gate.outputs.ok == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, ARM64, rpi]
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
## Why

`claude-code-review.yml` ran on GitHub-hosted `ubuntu-latest`, which is gated on org billing / spending limits. The org-level self-hosted **Pi 4 pool** (`[self-hosted, linux, ARM64, rpi]`, rpi-runner-01-01..04-01) is available to every RobotX-Workshops repo and bypasses that billing gate. tron-roboracer and esp32s3-uwb-positioning already use it.

## What

Switch `runs-on` from `ubuntu-latest` to `[self-hosted, linux, ARM64, rpi]` for the `secrets-gate` (+ `timeout-minutes: 5`) and `claude-review` (+ `timeout-minutes: 30`) jobs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790610553&installation_model_id=422527&pr_number=25&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F25&signature=f57cc49bade27474d749a07c2a1b80c0fcff0e41c43971c5f5c5837fd5ed9457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow jobs to run on a self-hosted ARM64 runner.
  * Added a five-minute timeout to the secrets validation job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->