### PR TITLE
ci: route bot blocking gate to org self-hosted Pi 4 runners

### DIFF
--- a/.github/workflows/bot-blocking-gate.yml
+++ b/.github/workflows/bot-blocking-gate.yml
@@ -87,7 +87,8 @@ permissions:
 
 jobs:
   gate:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, ARM64, rpi]
+    timeout-minutes: 10
     steps:
       - name: Resolve PR head SHA + fork status
         id: head

--- a/.github/workflows/bot-blocking-gate.yml
+++ b/.github/workflows/bot-blocking-gate.yml
@@ -90,6 +90,25 @@ jobs:
     runs-on: [self-hosted, linux, ARM64, rpi]
     timeout-minutes: 10
     steps:
+      - name: Preflight self-hosted runner prerequisites
+        run: |
+          set -euo pipefail
+          for tool in gh jq; do
+            command -v "$tool" >/dev/null 2>&1 || {
+              echo "::error::required tool '${tool}' missing on self-hosted runner"
+              exit 1
+            }
+          done
+          if ! printf 'x' | grep -qP 'x'; then
+            echo "::error::grep built without PCRE (-P) support, needed by the marker parser"
+            exit 1
+          fi
+          if ! gh api rate_limit >/dev/null 2>&1; then
+            echo "::error::gh cannot reach api.github.com (check outbound HTTPS and auth)"
+            exit 1
+          fi
+          echo "preflight ok: gh=$(gh --version | head -1), jq=$(jq --version | head -1)"
+
       - name: Resolve PR head SHA + fork status
         id: head
         env:
@@ -175,9 +194,12 @@ jobs:
             # --paginate into a single array; without it the jq filter
             # runs per page and run_id could come back multiline once
             # more than one page of runs exists for this SHA.
+            # `--slurp` is mutually exclusive with `--jq` on current `gh`
+            # (the runner rejects combining them with a usage error), so the
+            # pages are slurped into an array and filtered by piping to `jq`.
             run_id=$(gh api --paginate --slurp \
               "repos/${{ github.repository }}/actions/workflows/claude-code-review.yml/runs?head_sha=${SHA}&per_page=10" \
-              --jq '[.[].workflow_runs[]] | sort_by(.created_at) | reverse | .[0].id // empty')
+              | jq -r '[.[].workflow_runs[]] | sort_by(.created_at) | reverse | .[0].id // empty')
           fi
 
           if [[ -z "$run_id" ]]; then


### PR DESCRIPTION
## Why

PR #25 migrated `claude-code-review.yml` to the org self-hosted Pi pool, but `bot-blocking-gate.yml` (added in #10) was missed and still runs on `ubuntu-latest`. Route it to the org-level `[self-hosted, linux, ARM64, rpi]` pool to avoid the GitHub billing gate.

## What

Switch the `gate` job's `runs-on` from `ubuntu-latest` to `[self-hosted, linux, ARM64, rpi]` and add `timeout-minutes: 10`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/RobotX-Workshops/codesmith/dji-tello-playground/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790685755&installation_model_id=422527&pr_number=26&repository=RobotX-Workshops%2Fdji-tello-playground&return_to=https%3A%2F%2Fgithub.com%2FRobotX-Workshops%2Fdji-tello-playground%2Fpull%2F26&signature=ecbcdf4ba732be8297b96711814659003e6e2c3d1777785a63fe77e152686ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to run on a self-hosted ARM64 runner.
  * Added a 10-minute execution timeout to improve workflow reliability.
  * Added preflight validation for required command-line tools and service connectivity.
  * Improved workflow-run lookups to support paginated results more reliably.
  * These updates help automated checks fail faster and provide more consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->